### PR TITLE
Add GitHub Pages XML configurator for ModConfig-driven ship core files

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,37 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # SE Ship Core Framework
 This mod serves as an alternative to the standard block limit system in Space Engineers and some of the plugins for block limiting available through Torch. This mod is open to contribution but not distribution or uploading on the steam workshop or mod.io. Its exclusive rights belong to Blues-Hailfire and [ODB-Tech](odb-tech.com).
+
+## GitHub Pages XML Configurator
+A static configurator now lives under `docs/configurator` and is deployable through GitHub Pages.
+
+### What it does
+- Loads and parses `ModConfig.cs` (bundled copy or uploaded file) to expose XML-annotated classes.
+- Lets you build reusable `BlockGroup` definitions once and reference them from multiple core `BlockLimits`.
+- Generates downloadable XML outputs for:
+  - `ShipCoreConfig_Groups.xml`
+  - `ShipCoreConfig_Manifest.xml`
+  - individual `ShipCore` XML files (as a bundled text download)
+
+### Local preview
+```bash
+python3 -m http.server 8080 --directory docs
+```
+Then open `http://localhost:8080/configurator/`.

--- a/docs/configurator/app.js
+++ b/docs/configurator/app.js
@@ -1,0 +1,325 @@
+const state = {
+  schema: {},
+  blockGroups: [],
+  shipCores: []
+};
+
+const ids = (id) => document.getElementById(id);
+
+function escapeXml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", "&apos;");
+}
+
+function parseModConfigCs(source) {
+  const classes = {};
+  const classRegex = /public\s+class\s+(\w+)\s*\{([\s\S]*?)\n\s*\}/g;
+  let classMatch;
+  while ((classMatch = classRegex.exec(source)) !== null) {
+    const className = classMatch[1];
+    const body = classMatch[2];
+    const fields = [];
+    const fieldRegex = /\[XmlElement\("([^"]+)"\)\]\s*public\s+([^\s]+(?:\[\])?)\s+(\w+)/g;
+    let fieldMatch;
+    while ((fieldMatch = fieldRegex.exec(body)) !== null) {
+      fields.push({ xmlName: fieldMatch[1], type: fieldMatch[2], name: fieldMatch[3] });
+    }
+    if (fields.length) {
+      classes[className] = fields;
+    }
+  }
+  return classes;
+}
+
+function setParserStatus(text) {
+  ids("parserStatus").textContent = text;
+}
+
+function addBlockGroup(group = { name: "", blockTypes: [] }) {
+  state.blockGroups.push(group);
+  renderBlockGroups();
+  renderShipCores();
+}
+
+function addShipCore(core) {
+  state.shipCores.push(core ?? {
+    subtypeId: "",
+    uniqueName: "",
+    mobilityType: "Both",
+    maxBlocks: -1,
+    maxMass: -1,
+    maxPcu: -1,
+    maxPerPlayer: -1,
+    forceBroadcast: false,
+    forceBroadcastRange: 2000,
+    blockLimits: []
+  });
+  renderShipCores();
+}
+
+function blockTypeEditor(groupIdx, bt, btIdx) {
+  return `<div class="row wrap">
+    <input data-action="bt-type" data-g="${groupIdx}" data-i="${btIdx}" class="small" placeholder="TypeId" value="${escapeXml(bt.typeId)}" />
+    <input data-action="bt-subtype" data-g="${groupIdx}" data-i="${btIdx}" class="small" placeholder="SubtypeId (or any)" value="${escapeXml(bt.subtypeId)}" />
+    <input data-action="bt-weight" data-g="${groupIdx}" data-i="${btIdx}" class="small" type="number" step="0.1" value="${bt.countWeight}" />
+    <button data-action="remove-bt" data-g="${groupIdx}" data-i="${btIdx}">Remove BlockType</button>
+  </div>`;
+}
+
+function renderBlockGroups() {
+  const container = ids("blockGroups");
+  container.innerHTML = state.blockGroups.map((group, g) => `
+    <div class="card">
+      <h4>Group ${g + 1}</h4>
+      <div class="row wrap">
+        <input data-action="group-name" data-g="${g}" placeholder="Group Name" value="${escapeXml(group.name)}" />
+        <button data-action="add-bt" data-g="${g}">Add BlockType</button>
+        <button data-action="remove-group" data-g="${g}">Delete Group</button>
+      </div>
+      ${group.blockTypes.map((bt, i) => blockTypeEditor(g, bt, i)).join("")}
+    </div>
+  `).join("");
+}
+
+function blockGroupOptions(selected = []) {
+  return state.blockGroups
+    .filter((g) => g.name.trim())
+    .map((g) => `<option value="${escapeXml(g.name)}" ${selected.includes(g.name) ? "selected" : ""}>${escapeXml(g.name)}</option>`)
+    .join("");
+}
+
+function renderShipCores() {
+  const container = ids("shipCores");
+  container.innerHTML = state.shipCores.map((core, c) => `
+    <div class="card">
+      <h4>Core ${c + 1}</h4>
+      <div class="row wrap">
+        <input data-action="core-subtype" data-c="${c}" class="small" placeholder="SubtypeId" value="${escapeXml(core.subtypeId)}" />
+        <input data-action="core-unique" data-c="${c}" class="small" placeholder="UniqueName" value="${escapeXml(core.uniqueName)}" />
+        <select data-action="core-mobility" data-c="${c}" class="small">
+          ${["Static", "Mobile", "Both"].map(v => `<option ${core.mobilityType===v?"selected":""}>${v}</option>`).join("")}
+        </select>
+        <button data-action="remove-core" data-c="${c}">Delete Core</button>
+      </div>
+      <div class="row wrap">
+        <label class="inline">MaxBlocks <input data-action="core-maxblocks" data-c="${c}" class="small" type="number" value="${core.maxBlocks}" /></label>
+        <label class="inline">MaxMass <input data-action="core-maxmass" data-c="${c}" class="small" type="number" value="${core.maxMass}" /></label>
+        <label class="inline">MaxPCU <input data-action="core-maxpcu" data-c="${c}" class="small" type="number" value="${core.maxPcu}" /></label>
+        <label class="inline">MaxPerPlayer <input data-action="core-maxpp" data-c="${c}" class="small" type="number" value="${core.maxPerPlayer}" /></label>
+      </div>
+      <div class="row wrap">
+        <label class="inline">ForceBroadcast <input data-action="core-fb" data-c="${c}" type="checkbox" ${core.forceBroadcast ? "checked" : ""} /></label>
+        <label class="inline">BroadcastRange <input data-action="core-fbr" data-c="${c}" class="small" type="number" value="${core.forceBroadcastRange}" /></label>
+        <button data-action="add-limit" data-c="${c}">Add Block Limit</button>
+      </div>
+      ${core.blockLimits.map((limit, l) => `
+        <div class="card">
+          <div class="row wrap">
+            <input data-action="limit-name" data-c="${c}" data-l="${l}" class="small" placeholder="Limit Name" value="${escapeXml(limit.name)}" />
+            <label class="inline">MaxCount <input data-action="limit-max" data-c="${c}" data-l="${l}" class="small" type="number" step="0.1" value="${limit.maxCount}" /></label>
+            <button data-action="remove-limit" data-c="${c}" data-l="${l}">Delete Limit</button>
+          </div>
+          <div class="row wrap">
+            <label class="inline">PunishByNoFlyZone <input data-action="limit-punish" data-c="${c}" data-l="${l}" type="checkbox" ${limit.punishByNoFlyZone ? "checked" : ""}/></label>
+            <select data-action="limit-type" data-c="${c}" data-l="${l}" class="small">
+              ${["ShutOff", "Damage", "Delete", "Explode"].map(v => `<option ${limit.punishmentType===v?"selected":""}>${v}</option>`).join("")}
+            </select>
+            <input data-action="limit-dir" data-c="${c}" data-l="${l}" class="small" placeholder="AllowedDirections csv (Forward,Up)" value="${escapeXml((limit.allowedDirections || []).join(","))}" />
+          </div>
+          <div>
+            <label>Reusable Block Groups</label>
+            <select data-action="limit-groups" data-c="${c}" data-l="${l}" multiple>
+              ${blockGroupOptions(limit.blockGroups)}
+            </select>
+          </div>
+        </div>
+      `).join("")}
+    </div>
+  `).join("");
+}
+
+function generateXml() {
+  const header = '<?xml version="1.0" encoding="UTF-8"?>';
+
+  const groups = `${header}\n<ArrayOfBlockGroup>\n${state.blockGroups.map((g) => `  <BlockGroup>\n    <Name>${escapeXml(g.name)}</Name>\n${g.blockTypes.map((bt) => `    <BlockTypes>\n      <TypeId>${escapeXml(bt.typeId)}</TypeId>\n      <SubtypeId>${escapeXml(bt.subtypeId || "")}</SubtypeId>\n      <CountWeight>${bt.countWeight}</CountWeight>\n    </BlockTypes>`).join("\n")}\n  </BlockGroup>`).join("\n")}\n</ArrayOfBlockGroup>`;
+
+  const manifestFiles = state.shipCores
+    .filter((core) => core.subtypeId.trim())
+    .map((core) => `Data/Cores/${core.subtypeId}.xml`);
+
+  const manifest = `${header}\n<CoreManifest>\n${manifestFiles.map((f) => `  <ShipCoreFilenames>${escapeXml(f)}</ShipCoreFilenames>`).join("\n")}\n</CoreManifest>`;
+
+  const cores = state.shipCores.map((core) => {
+    const body = `${header}\n<ShipCore>\n  <SubtypeId>${escapeXml(core.subtypeId)}</SubtypeId>\n  <UniqueName>${escapeXml(core.uniqueName)}</UniqueName>\n  <ForceBroadCast>${core.forceBroadcast}</ForceBroadCast>\n  <ForceBroadCastRange>${core.forceBroadcastRange}</ForceBroadCastRange>\n  <MobilityType>${escapeXml(core.mobilityType)}</MobilityType>\n  <MaxBlocks>${core.maxBlocks}</MaxBlocks>\n  <MaxMass>${core.maxMass}</MaxMass>\n  <MaxPCU>${core.maxPcu}</MaxPCU>\n  <MaxPerPlayer>${core.maxPerPlayer}</MaxPerPlayer>\n${core.blockLimits.map((limit) => `  <BlockLimits>\n    <Name>${escapeXml(limit.name)}</Name>\n${limit.blockGroups.map((g) => `    <BlockGroups>${escapeXml(g)}</BlockGroups>`).join("\n")}\n    <MaxCount>${limit.maxCount}</MaxCount>\n    <PunishByNoFlyZone>${limit.punishByNoFlyZone}</PunishByNoFlyZone>\n    <PunishmentType>${escapeXml(limit.punishmentType)}</PunishmentType>\n${(limit.allowedDirections || []).filter(Boolean).map((d) => `    <AllowedDirections>${escapeXml(d)}</AllowedDirections>`).join("\n")}\n  </BlockLimits>`).join("\n")}\n</ShipCore>`;
+    return { file: `${core.subtypeId || "UnnamedCore"}.xml`, body };
+  });
+
+  ids("groupsXml").textContent = groups;
+  ids("manifestXml").textContent = manifest;
+  ids("coresXml").textContent = cores.map((c) => `===== ${c.file} =====\n${c.body}`).join("\n\n");
+
+  return { groups, manifest, cores };
+}
+
+function download(filename, content) {
+  const blob = new Blob([content], { type: "application/xml" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+document.addEventListener("click", (event) => {
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) return;
+  const action = target.dataset.action;
+  if (!action) return;
+
+  const g = Number(target.dataset.g);
+  const i = Number(target.dataset.i);
+  const c = Number(target.dataset.c);
+  const l = Number(target.dataset.l);
+
+  if (action === "add-bt") {
+    state.blockGroups[g].blockTypes.push({ typeId: "", subtypeId: "", countWeight: 1 });
+    renderBlockGroups();
+  } else if (action === "remove-bt") {
+    state.blockGroups[g].blockTypes.splice(i, 1);
+    renderBlockGroups();
+  } else if (action === "remove-group") {
+    state.blockGroups.splice(g, 1);
+    renderBlockGroups();
+    renderShipCores();
+  } else if (action === "remove-core") {
+    state.shipCores.splice(c, 1);
+    renderShipCores();
+  } else if (action === "add-limit") {
+    state.shipCores[c].blockLimits.push({ name: "", maxCount: 0, punishByNoFlyZone: false, punishmentType: "ShutOff", allowedDirections: [], blockGroups: [] });
+    renderShipCores();
+  } else if (action === "remove-limit") {
+    state.shipCores[c].blockLimits.splice(l, 1);
+    renderShipCores();
+  }
+});
+
+document.addEventListener("input", (event) => {
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) return;
+  const action = target.dataset.action;
+  if (!action) return;
+
+  const g = Number(target.dataset.g);
+  const i = Number(target.dataset.i);
+  const c = Number(target.dataset.c);
+  const l = Number(target.dataset.l);
+
+  if (action === "group-name") state.blockGroups[g].name = target.value;
+  if (action === "bt-type") state.blockGroups[g].blockTypes[i].typeId = target.value;
+  if (action === "bt-subtype") state.blockGroups[g].blockTypes[i].subtypeId = target.value;
+  if (action === "bt-weight") state.blockGroups[g].blockTypes[i].countWeight = Number(target.value || 0);
+
+  if (action === "core-subtype") state.shipCores[c].subtypeId = target.value;
+  if (action === "core-unique") state.shipCores[c].uniqueName = target.value;
+  if (action === "core-maxblocks") state.shipCores[c].maxBlocks = Number(target.value || -1);
+  if (action === "core-maxmass") state.shipCores[c].maxMass = Number(target.value || -1);
+  if (action === "core-maxpcu") state.shipCores[c].maxPcu = Number(target.value || -1);
+  if (action === "core-maxpp") state.shipCores[c].maxPerPlayer = Number(target.value || -1);
+  if (action === "core-fbr") state.shipCores[c].forceBroadcastRange = Number(target.value || 0);
+
+  if (action === "limit-name") state.shipCores[c].blockLimits[l].name = target.value;
+  if (action === "limit-max") state.shipCores[c].blockLimits[l].maxCount = Number(target.value || 0);
+  if (action === "limit-dir") state.shipCores[c].blockLimits[l].allowedDirections = target.value.split(",").map((v) => v.trim()).filter(Boolean);
+});
+
+document.addEventListener("change", (event) => {
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) return;
+  const action = target.dataset.action;
+
+  if (action === "core-fb") {
+    state.shipCores[Number(target.dataset.c)].forceBroadcast = target.checked;
+  }
+  if (action === "core-mobility") {
+    state.shipCores[Number(target.dataset.c)].mobilityType = target.value;
+  }
+  if (action === "limit-punish") {
+    state.shipCores[Number(target.dataset.c)].blockLimits[Number(target.dataset.l)].punishByNoFlyZone = target.checked;
+  }
+  if (action === "limit-type") {
+    state.shipCores[Number(target.dataset.c)].blockLimits[Number(target.dataset.l)].punishmentType = target.value;
+  }
+  if (action === "limit-groups") {
+    const core = state.shipCores[Number(target.dataset.c)];
+    const limit = core.blockLimits[Number(target.dataset.l)];
+    limit.blockGroups = Array.from(target.selectedOptions).map((o) => o.value);
+  }
+
+  const fileInput = ids("modConfigFile");
+  if (target === fileInput) {
+    const file = fileInput.files?.[0];
+    if (!file) return;
+    file.text().then((text) => {
+      ids("modConfigInput").value = text;
+      const schema = parseModConfigCs(text);
+      state.schema = schema;
+      ids("schemaPreview").textContent = JSON.stringify(schema, null, 2);
+      setParserStatus(`Parsed ${Object.keys(schema).length} classes from ${file.name}.`);
+    });
+  }
+});
+
+ids("addGroup").addEventListener("click", () => addBlockGroup({ name: "", blockTypes: [] }));
+ids("addCore").addEventListener("click", () => addShipCore());
+
+ids("loadBundled").addEventListener("click", async () => {
+  const response = await fetch("./assets/ModConfig.cs");
+  const text = await response.text();
+  ids("modConfigInput").value = text;
+  state.schema = parseModConfigCs(text);
+  ids("schemaPreview").textContent = JSON.stringify(state.schema, null, 2);
+  setParserStatus(`Parsed ${Object.keys(state.schema).length} classes from bundled ModConfig.cs.`);
+});
+
+ids("generateXml").addEventListener("click", () => generateXml());
+ids("downloadGroups").addEventListener("click", () => {
+  const xml = generateXml();
+  download("ShipCoreConfig_Groups.xml", xml.groups);
+});
+ids("downloadManifest").addEventListener("click", () => {
+  const xml = generateXml();
+  download("ShipCoreConfig_Manifest.xml", xml.manifest);
+});
+ids("downloadCores").addEventListener("click", () => {
+  const xml = generateXml();
+  const content = xml.cores.map((c) => `### ${c.file}\n${c.body}`).join("\n\n");
+  download("ShipCore_Cores_Bundle.txt", content);
+});
+
+addBlockGroup({ name: "Weaponry", blockTypes: [{ typeId: "SmallGatlingGun", subtypeId: "", countWeight: 1 }] });
+addShipCore({
+  subtypeId: "Fighter_Core",
+  uniqueName: "Fighter Grid Class",
+  mobilityType: "Mobile",
+  maxBlocks: 1000,
+  maxMass: -1,
+  maxPcu: 6000,
+  maxPerPlayer: 10,
+  forceBroadcast: true,
+  forceBroadcastRange: 2000,
+  blockLimits: [{
+    name: "Weapons",
+    maxCount: 8,
+    punishByNoFlyZone: true,
+    punishmentType: "Delete",
+    allowedDirections: ["Forward"],
+    blockGroups: ["Weaponry"]
+  }]
+});
+
+generateXml();

--- a/docs/configurator/assets/ModConfig.cs
+++ b/docs/configurator/assets/ModConfig.cs
@@ -1,0 +1,506 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Serialization;
+using Sandbox.ModAPI;
+using VRageMath;
+
+namespace ShipCoreFramework
+{
+    [XmlRoot("ModConfig")]
+    public class ModConfig
+    {
+        [XmlIgnore] private const string IgnoreAiKey = "ShipCore.IgnoreAiV1";
+        [XmlIgnore] private const string IgnoredFactionsKey = "ShipCore.IgnoredFactionsV1";
+        [XmlIgnore] private const string SelectedNoCoreKey = "ShipCore.SelectedNoCoreBlobV1";
+        [XmlIgnore] private const string GlobalConfigFileName = "ShipCoreConfig_World.xml";
+        [XmlIgnore] private const string CoreManifestFileName = @"Data\ShipCoreConfig_Manifest.xml";
+        [XmlIgnore] private const string BlockGroupsFileName = @"Data\ShipCoreConfig_Groups.xml";
+        [XmlIgnore] private const string DefaultNoCoreFileName = @"Data\ShipCoreConfig_No_Core.xml";
+        [XmlIgnore] public readonly List<ShipCore> NoCoreConfigs = new List<ShipCore>();
+        [XmlIgnore] public readonly List<BlockGroup> BlockGroups = new List<BlockGroup>();
+        [XmlIgnore] public readonly List<ShipCore> ShipCores = new List<ShipCore>();
+        [XmlIgnore] public List<string> IgnoredFactionTags = new List<string>();
+        [XmlIgnore] public ShipCore SelectedNoCore;
+        [XmlIgnore] public bool IgnoreAiFactions;
+        
+        [XmlElement("DebugMode")] public bool DebugMode;
+        [XmlElement("CombatLogging")] public bool CombatLogging = true;
+        [XmlElement("LOG_LEVEL")]public int LogLevel = 2; //messages with logPriority >= this will get logged, less than will be ignored
+        [XmlElement("CLIENT_OUTPUT_LOG_LEVEL")]public int ClientOutputLogLevel = 2; //messages with logPriority >= this will get output to clients
+
+        [XmlElement("MaxPossibleSpeedMetersPerSecond")] public float MaxPossibleSpeedMetersPerSecond = 300;
+        [XmlElement("FrictionSpeedValueMode")] public FrictionSpeedValueMode FrictionSpeedValueMode = FrictionSpeedValueMode.Modifier;
+        [XmlElement("NoFlyZones")] public List<Zones> NoFlyZones = new List<Zones>();
+        
+        public ShipCore GetShipCoreByTypeId(string coreTypeId)
+        {
+            if (coreTypeId == string.Empty) return SelectedNoCore;
+            var shipCore = ShipCores.FirstOrDefault(core => core.SubtypeId == coreTypeId);
+            return shipCore ?? SelectedNoCore;
+        }
+
+        public bool IsValidCoreType(string coreTypeName)
+        {
+            return ShipCores.Any(core => core.SubtypeId == coreTypeName);
+        }
+
+        public void SaveConfig(bool showInChat = false)
+        {
+            try
+            {
+                var globalConfigWriter = MyAPIGateway.Utilities.WriteFileInWorldStorage(GlobalConfigFileName, typeof(ModConfig));
+                globalConfigWriter.Write(MyAPIGateway.Utilities.SerializeToXML(this));
+                globalConfigWriter.Close();
+                Utils.Log($"Save Config: Saved {GlobalConfigFileName}", showInChat ? 3 : 0);
+                Utils.SaveToSandbox(IgnoreAiKey, IgnoreAiFactions);
+                Utils.Log($"Stored Data In World Config: Saved {IgnoreAiKey}", showInChat ? 3 : 0);
+                Utils.SaveToSandbox(IgnoredFactionsKey, IgnoredFactionTags);
+                Utils.Log($"Stored Data In World Config: : Saved {IgnoredFactionsKey}", showInChat ? 3 : 0);
+                Utils.SaveToSandbox(SelectedNoCoreKey, SelectedNoCore);
+                Utils.Log($"Stored Data In World Config: : Saved {SelectedNoCoreKey}", showInChat ? 3 : 0);
+            }
+            catch (Exception e)
+            {
+                //Utils.Log($"Failed to save configs, reason {e.Message}", 3);
+                Utils.Log($"Save Error: {e}");
+                var globalConfigWriter = MyAPIGateway.Utilities.WriteFileInWorldStorage("Error.txt", typeof(ModConfig));
+                globalConfigWriter.Write(e);
+                globalConfigWriter.Close();
+            }
+        }
+        
+        public void LoadConfig()
+        {
+            //Get World Settings
+            if (MyAPIGateway.Utilities.FileExistsInWorldStorage(GlobalConfigFileName, typeof(ModConfig)))
+            {
+                using (var reader = MyAPIGateway.Utilities.ReadFileInWorldStorage(GlobalConfigFileName, typeof(ModConfig)))
+                {
+                    var text = reader.ReadToEnd();
+                    var import = MyAPIGateway.Utilities.SerializeFromXML<ModConfig>(text);
+                    if (import == null) throw new Exception("Failed to load world config.");
+
+                    DebugMode = !Session.IsClient && import.DebugMode;
+                    CombatLogging = import.CombatLogging;
+                    LogLevel = import.LogLevel;
+                    ClientOutputLogLevel = import.ClientOutputLogLevel;
+
+                    if (import.MaxPossibleSpeedMetersPerSecond <= 0 || import.MaxPossibleSpeedMetersPerSecond > 10000)
+                    {
+                        Utils.Log("MaxPossibleSpeedMetersPerSecond validation failed - using default 300", 0, "Config Validation");
+                        MaxPossibleSpeedMetersPerSecond = 300;
+                    }
+                    else
+                    {
+                        MaxPossibleSpeedMetersPerSecond = import.MaxPossibleSpeedMetersPerSecond;
+                    }
+
+                    FrictionSpeedValueMode = import.FrictionSpeedValueMode;
+                    NoFlyZones = import.NoFlyZones;
+                }
+            }
+            else
+            {
+                //Write Global Settings using predefined values
+                var globalConfigWriter = MyAPIGateway.Utilities.WriteFileInWorldStorage(GlobalConfigFileName, typeof(ModConfig));
+                globalConfigWriter.Write(MyAPIGateway.Utilities.SerializeToXML(this));
+                globalConfigWriter.Close();
+            }
+
+            IgnoreAiFactions = Utils.LoadFromSandbox<bool>(IgnoreAiKey);
+            IgnoredFactionTags = Utils.LoadFromSandbox<List<string>>(IgnoredFactionsKey) ?? new List<string>{"SPRT","ADMIN","FMCA", "BORG", "TERA"};
+            SelectedNoCore = Utils.LoadFromSandbox<ShipCore>(SelectedNoCoreKey);
+            
+            //Run Though Mods
+            foreach (var mod in MyAPIGateway.Session.Mods)
+            {
+                //Add Custom BlockGroups
+                if (MyAPIGateway.Utilities.FileExistsInModLocation(BlockGroupsFileName, mod))
+                    using (var reader = MyAPIGateway.Utilities.ReadFileInModLocation(BlockGroupsFileName, mod))
+                    {
+                        var text = reader.ReadToEnd();
+                        var newBlockGroups = MyAPIGateway.Utilities.SerializeFromXML<List<BlockGroup>>(text);
+
+                        if (newBlockGroups == null)
+                            throw new Exception($"Failed to load block groups from Mod: {mod.FriendlyName}");
+                        BlockGroups.AddRange(newBlockGroups);
+                        Utils.Log($"Loaded Groups From: {mod.FriendlyName}", 1, "Ship Core Config");
+                    }
+
+                //Add default Core to list
+                if (MyAPIGateway.Utilities.FileExistsInModLocation(DefaultNoCoreFileName, mod))
+                    using (var reader = MyAPIGateway.Utilities.ReadFileInModLocation(DefaultNoCoreFileName, mod))
+                    {
+                        var text = reader.ReadToEnd();
+                        var newNoCore = MyAPIGateway.Utilities.SerializeFromXML<ShipCore>(text);
+
+                        if (newNoCore == null)
+                            throw new Exception($"Failed to load no-core from Mod: {mod.FriendlyName}");
+                        NoCoreConfigs.Add(newNoCore);
+                        Utils.Log($"Loaded No-Core Config From: {mod.FriendlyName}", 1, "Ship Core Config");
+                    }
+
+                if (!MyAPIGateway.Utilities.FileExistsInModLocation(CoreManifestFileName, mod)) continue;
+                Utils.Log($"Found Manifest in: {mod.FriendlyName}", 1, "Ship Core Config");
+                //Check the Core Manifest to get all cores in the mod
+                using (var reader = MyAPIGateway.Utilities.ReadFileInModLocation(CoreManifestFileName, mod))
+                {
+                    var text = reader.ReadToEnd();
+                    var coreManifest = MyAPIGateway.Utilities.SerializeFromXML<CoreManifest>(text);
+                    if (coreManifest == null)
+                        throw new Exception($"Failed to Load Classes from Mod: {mod.FriendlyName}");
+
+                    //Go get ship cores
+                    foreach (var shipCoreFilename in coreManifest.ShipCoreFilenames.Where(shipCoreFilename => MyAPIGateway.Utilities.FileExistsInModLocation(shipCoreFilename, mod)))
+                        using (var textReader = MyAPIGateway.Utilities.ReadFileInModLocation(shipCoreFilename, mod))
+                        {
+                            var modText = textReader.ReadToEnd();
+                            var newShipCore = MyAPIGateway.Utilities.SerializeFromXML<ShipCore>(modText);
+
+                            if (newShipCore == null){throw new Exception($"Failed to load ship core from file {shipCoreFilename} in Mod: {mod.FriendlyName}");}
+                            ShipCores.Add(newShipCore);
+                            Utils.Log($"Loaded Core {newShipCore.UniqueName} From: {mod.FriendlyName}", 1, "Ship Core Config");
+                        }
+                }
+            }
+
+            ThrowErrorIfDuplicates(NoCoreConfigs, core => core.UniqueName);
+            ThrowErrorIfDuplicates(ShipCores, core => core.UniqueName);
+            ThrowErrorIfDuplicates(BlockGroups, groups => groups.Name);
+            Utils.Log($"NoCoreConfigs.Count = {NoCoreConfigs.Count}", 1, "Ship Core Config");
+            Utils.Log($"BlockGroups.Count = {BlockGroups.Count}", 1, "Ship Core Config");
+
+            foreach (var limit in ShipCores.SelectMany(core => core.BlockLimits))
+            {
+                foreach(var shorthand in limit.BlockGroupsShortHand)
+                {
+                    foreach (var group in BlockGroups.Where(group => group.Name == shorthand))
+                    {
+                        limit.BlockGroups.Add(group);
+                        Utils.Log($"{group.Name} Count: {limit.BlockGroups.Count}",0, "Ship Core Config groups");
+                    }
+                }
+            }
+            //Select the default config instead of returning
+            if (SelectedNoCore == null) SelectedNoCore=DefaultNoCoreConfig.ShipCore;
+            foreach(var limit in SelectedNoCore.BlockLimits)
+            {
+                foreach(var shorthand in limit.BlockGroupsShortHand)
+                {
+                    foreach (var group in BlockGroups.Where(group => group.Name == shorthand))
+                    {
+                        limit.BlockGroups.Add(group);
+                        Utils.Log($"{group.Name} Count: {limit.BlockGroups.Count}",0, "Ship Core Config groups");
+                    }
+                }
+            }
+        }
+
+        private static void ThrowErrorIfDuplicates<T, TKey>(List<T> list, Func<T, TKey> selector)
+        {
+            var dupeList = list.GroupBy(selector)
+                .Where(g => g.Count() > 1)
+                .Select(g => g.Key)
+                .ToList();
+            
+            if (dupeList.Any())
+            {
+                throw new Exception($"Found duplicates f0r {selector.Method.Name}: {string.Join("\n- ", dupeList)}");
+            }
+        }
+    }
+    
+    [XmlRoot("Zones")]
+	public class Zones {
+        [XmlElement("ID")]
+		public int Id;
+        [XmlElement("Position")]
+        public Vector3D Position;
+        [XmlElement("Radius")]
+        public double Radius;
+        [XmlElement("AllowedCoresSubtype")]
+        public List<string> AllowedCoresSubtype = new List<string>();
+        [XmlElement("OverideBlockLimitsForceShutOff")]
+        public bool ForceOff;
+    }
+    
+    [XmlRoot("CoreManifest")]
+    public class CoreManifest
+    {
+        [XmlElement("ShipCoreFilenames")] public List<string> ShipCoreFilenames;
+    }
+    
+    [XmlRoot("ShipCore")]
+    public class ShipCore
+    {
+        [XmlElement("SubtypeId")]
+        public string SubtypeId = string.Empty;
+        [XmlElement("UniqueName")]
+        public string UniqueName = string.Empty;
+        [XmlElement("MaxBackupCores")]
+        public int MaxBackupCores = -1;
+        [XmlElement("ForceBroadCast")]
+        public bool ForceBroadCast;
+        [XmlElement("ForceBroadCastRange")]
+        public float ForceBroadCastRange;
+        [XmlElement("MobilityType")]
+        public MobilityType MobilityType = MobilityType.Both;
+        [XmlElement("MaxBlocks")]
+        public int MaxBlocks = -1;
+        [XmlElement("MaxMass")]
+        public float MaxMass = -1;
+        [XmlElement("MaxPCU")]
+        public int MaxPCU = -1;
+        [XmlElement("MaxPerFaction")]
+        public int MaxPerFaction = -1;
+        [XmlElement("MaxPerPlayer")]
+        public int MaxPerPlayer = -1;
+        [XmlElement("MinPlayers")]
+        public int MinPlayers = -1;
+        [XmlElement("Modifiers")]
+        public GridModifiers Modifiers = new GridModifiers();
+        [XmlElement("PassiveDefenseModifiers")]
+        public GridDefenseModifiers PassiveDefenseModifiers = new GridDefenseModifiers();
+        [XmlElement("SpeedBoostEnabled")]
+        public bool SpeedBoostEnabled;
+        [XmlElement("SpeedLimitType")]
+        public SpeedLimitType SpeedLimitType;
+        [XmlElement("SpeedModifiers")]
+        public SpeedModifiers SpeedModifiers = new SpeedModifiers();
+        [XmlElement("EnableActiveDefenseModifiers")]
+        public bool EnableActiveDefenseModifiers;
+        [XmlElement("ActiveDefenseModifiers")]
+        public GridDefenseModifiers ActiveDefenseModifiers = new GridDefenseModifiers();
+        [XmlElement("BlockLimits")]
+        public BlockLimit[] BlockLimits = Array.Empty<BlockLimit>();
+    }
+    
+    [XmlRoot("SpeedModifiers")]
+    public class SpeedModifiers
+    {
+        [XmlElement("MaxSpeed")]
+        public float MaxSpeed = 0.3f;
+        [XmlElement("MaxBoost")]
+        public float MaxBoost = 0.5f;
+        [XmlElement("BoostDuration")]
+        public float BoostDuration = 10f; 
+        [XmlElement("BoostCoolDown")]
+        public float BoostCoolDown = 60f;      
+        [XmlElement("MinimumFrictionSpeedAbsolute")]
+        public float MinimumFrictionSpeedAbsolute = 100f;
+        [XmlElement("MaximumFrictionSpeedAbsolute")]
+        public float MaximumFrictionSpeedAbsolute = 290f;
+        [XmlElement("MinimumFrictionSpeedModifier")]
+        public float MinimumFrictionSpeedModifier = 0.3f;
+        [XmlElement("MaximumFrictionSpeedModifier")]
+        public float MaximumFrictionSpeedModifier = 0.8f;
+        [XmlElement("MaximumFrictionDeceleration")]
+        public float MaximumFrictionDeceleration= 1f;  
+    }
+    
+    [XmlRoot("GridModifiers")]
+    public class GridModifiers
+    {
+        [XmlElement("AssemblerSpeed")]
+        public float AssemblerSpeed = 1;
+        [XmlElement("DrillHarvestMultiplier")]
+        public float DrillHarvestMultiplier = 1;
+        [XmlElement("GyroEfficiency")]
+        public float GyroEfficiency = 1;
+        [XmlElement("GyroForce")]
+        public float GyroForce = 1;
+        [XmlElement("PowerProducersOutput")]
+        public float PowerProducersOutput = 1;
+        [XmlElement("RefineEfficiency")]
+        public float RefineEfficiency = 1;
+        [XmlElement("RefineSpeed")]
+        public float RefineSpeed = 1;
+        [XmlElement("ThrusterEfficiency")]
+        public float ThrusterEfficiency = 1;
+        [XmlElement("ThrusterForce")]
+        public float ThrusterForce = 1;
+        
+        public override string ToString()
+        {
+            return
+                $"<GridModifiers ThrusterForce={ThrusterForce} " +
+                $"ThrusterEfficiency={ThrusterEfficiency} " +
+                $"GyroForce={GyroForce} " +
+                $"GyroEfficiency={GyroEfficiency} " +
+                $"RefineEfficiency={RefineEfficiency} " +
+                $"RefineSpeed={RefineSpeed} " +
+                $"AssemblerSpeed={AssemblerSpeed} " +
+                $"PowerProducersOutput={PowerProducersOutput} " +
+                $"DrillHarvestMultiplier={DrillHarvestMultiplier} />";
+        }
+
+        public List<ModifierNameValue> GetModifierValues()
+        {
+            return new List<ModifierNameValue>
+            {
+                new ModifierNameValue("Thruster force", ThrusterForce),
+                new ModifierNameValue("Thruster efficiency", ThrusterEfficiency),
+                new ModifierNameValue("Gyro force", GyroForce),
+                new ModifierNameValue("Gyro efficiency", GyroEfficiency),
+                new ModifierNameValue("Refinery efficiency", RefineEfficiency),
+                new ModifierNameValue("Refinery speed", RefineSpeed),
+                new ModifierNameValue("Assembler speed", AssemblerSpeed),
+                new ModifierNameValue("Power output", PowerProducersOutput),
+                new ModifierNameValue("Drill harvest", DrillHarvestMultiplier)
+            };
+        }
+    }
+
+    public struct ModifierNameValue
+    {
+        public readonly string Name;
+        public readonly float Value;
+
+        public ModifierNameValue(string name, float value)
+        {
+            Name = name;
+            Value = value;
+        }
+    }
+
+    [XmlRoot("BlockLimit")]
+    public class BlockLimit
+    {
+        [XmlElement("Name")]
+        public string Name = string.Empty;
+        [XmlElement("BlockGroups")]
+        public string[] BlockGroupsShortHand = Array.Empty<string>();
+        [XmlIgnore]
+        public List<BlockGroup> BlockGroups = new List<BlockGroup>();
+        [XmlElement("MaxCount")]
+        public float MaxCount;
+        [XmlElement("PunishByNoFlyZone")]
+        public bool PunishByNoFlyZone;
+        [XmlElement("PunishmentType")]
+        public PunishmentType PunishmentType = PunishmentType.ShutOff;
+        [XmlElement("AllowedDirections")]
+        public List<DirectionType> AllowedDirections;
+
+        internal double GetWeight(BlockKey key)
+        {
+            if (BlockGroups == null) return 0d;
+
+            foreach (var group in BlockGroups)
+            {
+                if (group?.BlockTypes == null) continue;
+
+                foreach (var blockType in group.BlockTypes)
+                {
+                    if (blockType == null) continue;
+
+                    if (blockType.TypeId != key.TypeId) continue;
+                    if (blockType.SubtypeId == key.SubtypeId || blockType.SubtypeId == "any")
+                    {
+                        return blockType.CountWeight;
+                    }
+                }
+            }
+            return 0d;
+        }
+    }
+
+    [XmlRoot("BlockGroup")]
+    public class BlockGroup
+    {
+        [XmlElement("Name")] 
+        public string Name = string.Empty;
+        [XmlElement("BlockTypes")] 
+        public List<BlockType> BlockTypes = new List<BlockType>();
+    }
+
+    [XmlRoot("BlockType")]
+    public class BlockType
+    {
+        [XmlElement("TypeId")] 
+        public string TypeId;
+        [XmlElement("SubtypeId")] 
+        public string SubtypeId;
+        [XmlElement("CountWeight")] 
+        public float CountWeight;
+        
+        public BlockType()
+        {
+            TypeId = string.Empty;
+            SubtypeId = string.Empty;
+            CountWeight = 1;
+        }
+
+        public BlockType(string typeId, string subtypeId = "", float countWeight = 1)
+        {
+            TypeId = typeId;
+            SubtypeId = subtypeId;
+            CountWeight = countWeight;
+        }
+    }
+
+    [XmlRoot("GridDefenseModifiers")]
+    public class GridDefenseModifiers
+    {
+        [XmlElement("Bullet")] 
+        public float Bullet = 1f;
+        [XmlElement("PostShield")] 
+        public float PostShield = 1f;
+        [XmlElement("Duration")] 
+        public float Duration;
+        [XmlElement("Cooldown")] 
+        public float Cooldown;
+        [XmlElement("Rocket")] 
+        public float Rocket = 1f;
+        [XmlElement("Explosion")] 
+        public float Explosion = 1f;
+        [XmlElement("Environment")] 
+        public float Environment = 1f;
+        [XmlElement("Energy")] 
+        public float Energy = 1f;
+        [XmlElement("Kinetic")] 
+        public float Kinetic = 1f;
+    }
+    
+    [XmlRoot("MobilityType")]
+    public enum MobilityType
+    {
+        Static = 0, 
+        Mobile = 1, 
+        Both = 2
+    }
+    
+    [XmlRoot("SpeedLimitType")]
+    public enum SpeedLimitType
+    {
+        Normal = 0, 
+        Friction = 1
+    }
+
+    [XmlRoot("FrictionSpeedValueMode")]
+    public enum FrictionSpeedValueMode
+    {
+        Modifier = 0,
+        Absolute = 1
+    }
+
+    [XmlRoot("PunishmentType")]
+    public enum PunishmentType
+    {
+        ShutOff,
+        Damage,
+        Delete,
+        Explode
+    }
+
+    [XmlRoot("DirectionType")]
+    public enum DirectionType
+    {
+        Forward,
+        Backward,
+        Up,
+        Down,
+        Left,
+        Right,
+    }
+}

--- a/docs/configurator/index.html
+++ b/docs/configurator/index.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SE Ship Core XML Configurator</title>
+  <link rel="stylesheet" href="./styles.css" />
+</head>
+<body>
+  <header>
+    <h1>SE Ship Core XML Configurator</h1>
+    <p>Parse <code>ModConfig.cs</code>, manage reusable block groups, and generate XML for your mod package.</p>
+  </header>
+
+  <main>
+    <section class="panel">
+      <h2>1) Load ModConfig.cs</h2>
+      <div class="row">
+        <button id="loadBundled">Load bundled ModConfig.cs</button>
+        <input id="modConfigFile" type="file" accept=".cs" />
+      </div>
+      <textarea id="modConfigInput" rows="10" placeholder="Paste ModConfig.cs content here"></textarea>
+      <div id="parserStatus" class="muted">No file parsed yet.</div>
+      <pre id="schemaPreview" class="code-block"></pre>
+    </section>
+
+    <section class="panel">
+      <h2>2) Reusable Block Groups</h2>
+      <button id="addGroup">Add Block Group</button>
+      <div id="blockGroups"></div>
+    </section>
+
+    <section class="panel">
+      <h2>3) Ship Cores</h2>
+      <button id="addCore">Add Ship Core</button>
+      <div id="shipCores"></div>
+    </section>
+
+    <section class="panel">
+      <h2>4) Generated XML</h2>
+      <div class="row wrap">
+        <button id="generateXml">Generate</button>
+        <button id="downloadGroups">Download ShipCoreConfig_Groups.xml</button>
+        <button id="downloadManifest">Download ShipCoreConfig_Manifest.xml</button>
+        <button id="downloadCores">Download all ShipCore XMLs (.zip-like text bundle)</button>
+      </div>
+      <h3>ShipCoreConfig_Groups.xml</h3>
+      <pre id="groupsXml" class="code-block"></pre>
+      <h3>ShipCoreConfig_Manifest.xml</h3>
+      <pre id="manifestXml" class="code-block"></pre>
+      <h3>ShipCore XML Files</h3>
+      <pre id="coresXml" class="code-block"></pre>
+    </section>
+  </main>
+
+  <script type="module" src="./app.js"></script>
+</body>
+</html>

--- a/docs/configurator/styles.css
+++ b/docs/configurator/styles.css
@@ -1,0 +1,64 @@
+:root {
+  color-scheme: dark;
+  --bg: #111827;
+  --panel: #1f2937;
+  --accent: #22d3ee;
+  --text: #e5e7eb;
+  --muted: #9ca3af;
+}
+body {
+  margin: 0;
+  font-family: Inter, system-ui, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+header, main {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+.panel {
+  background: var(--panel);
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+.row { display: flex; gap: 0.5rem; align-items: center; margin-bottom: 0.5rem; }
+.wrap { flex-wrap: wrap; }
+textarea, input, select {
+  width: 100%;
+  margin: 0.35rem 0;
+  padding: 0.45rem;
+  border-radius: 6px;
+  border: 1px solid #374151;
+  background: #111827;
+  color: var(--text);
+}
+button {
+  background: #0f766e;
+  color: white;
+  border: 0;
+  border-radius: 6px;
+  padding: 0.5rem 0.8rem;
+  cursor: pointer;
+}
+button:hover { background: #0d9488; }
+.code-block {
+  background: #0b1220;
+  border: 1px solid #374151;
+  border-radius: 8px;
+  padding: 0.75rem;
+  white-space: pre-wrap;
+  max-height: 300px;
+  overflow: auto;
+}
+.card {
+  border: 1px solid #374151;
+  border-radius: 8px;
+  padding: 0.75rem;
+  margin: 0.65rem 0;
+}
+.card h4 { margin: 0.25rem 0 0.5rem; }
+.small { width: 220px; }
+.inline { display: inline-flex; gap: 0.5rem; align-items: center; margin-right: 1rem; }
+.muted { color: var(--muted); }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="refresh" content="0; url=./configurator/" />
+  <title>SE Ship Core Docs</title>
+</head>
+<body>
+  <p>Redirecting to <a href="./configurator/">configurator</a>…</p>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a small, static, GitHub Pages-hosted XML configurator that parses the existing `ModConfig.cs` model and produces the XML files expected by the mod (groups, manifest, and per-core files). 
- Make `BlockGroup` definitions reusable across multiple `BlockLimit` entries so groups can be authored once and referenced by many cores.

### Description
- Added a static configurator under `docs/configurator` with `index.html`, `styles.css`, and `app.js` implementing a UI to load/parse `ModConfig.cs`, manage reusable block groups, edit ship cores and block limits, and generate/download XML outputs. 
- Bundled a snapshot of `ModConfig.cs` at `docs/configurator/assets/ModConfig.cs` and implemented a simple parser that extracts fields annotated with `[XmlElement]` to help surface the schema in the UI. 
- Implemented XML generation and download for `ShipCoreConfig_Groups.xml`, `ShipCoreConfig_Manifest.xml`, and a bundled publication of generated `ShipCore` XML files, and seeded example data for immediate preview. 
- Added `docs/index.html` (redirect to configurator), updated `README.md` with usage/local preview instructions, and added a GitHub Actions workflow at `.github/workflows/pages.yml` to deploy the `docs/` folder to GitHub Pages.

### Testing
- Ran `git diff --check` with no warnings or errors reported. 
- Launched a local HTTP server via `python3 -m http.server 8080 --directory docs` and confirmed the configurator served successfully. 
- Executed an automated Playwright script that opened `http://127.0.0.1:8080/configurator/` and captured a full-page screenshot, which completed successfully and produced the artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cd8e67c688323891a239649eee998)