### PR TITLE
Balance modifier/input padding, contain file inputs, and expand core modifiers UI

### DIFF
--- a/docs/configurator/app.js
+++ b/docs/configurator/app.js
@@ -193,9 +193,9 @@ function resetEditor(seed = true) {
 
 function blockTypeEditor(groupIdx, blockType, blockTypeIdx) {
   return `<div class="row wrap">
-    <input data-action="bt-type" data-g="${groupIdx}" data-i="${blockTypeIdx}" class="small" placeholder="TypeId" value="${escapeXml(blockType.typeId)}" />
-    <input data-action="bt-subtype" data-g="${groupIdx}" data-i="${blockTypeIdx}" class="small" placeholder="SubtypeId (or any)" value="${escapeXml(blockType.subtypeId)}" />
-    <input data-action="bt-weight" data-g="${groupIdx}" data-i="${blockTypeIdx}" class="small" type="number" step="0.1" value="${blockType.countWeight}" />
+    <input data-action="bt-type" data-g="${groupIdx}" data-i="${blockTypeIdx}" class="small" placeholder="TypeId" title="Block TypeId. Example: SmallGatlingGun." value="${escapeXml(blockType.typeId)}" />
+    <input data-action="bt-subtype" data-g="${groupIdx}" data-i="${blockTypeIdx}" class="small" placeholder="SubtypeId (or any)" title="Optional block subtype filter. Use &quot;any&quot; to match all subtypes." value="${escapeXml(blockType.subtypeId)}" />
+    <input data-action="bt-weight" data-g="${groupIdx}" data-i="${blockTypeIdx}" class="small" type="number" step="0.1" title="Weight contribution for matching blocks in this group." value="${blockType.countWeight}" />
     <button data-action="remove-bt" data-g="${groupIdx}" data-i="${blockTypeIdx}">Remove BlockType</button>
   </div>`;
 }
@@ -227,7 +227,7 @@ function renderBlockGroups() {
   ids("blockGroups").innerHTML = `
     <div class="card">
       <div class="row wrap">
-        <input data-action="group-name" data-g="${groupIndex}" placeholder="Group Name" value="${escapeXml(group.name)}" />
+        <input data-action="group-name" data-g="${groupIndex}" placeholder="Group Name" title="Reusable block group name referenced by block limits." value="${escapeXml(group.name)}" />
         <button data-action="add-bt" data-g="${groupIndex}">Add BlockType</button>
         <button data-action="remove-group" data-g="${groupIndex}">Delete Group</button>
       </div>
@@ -288,9 +288,9 @@ function renderShipCores() {
   ids("shipCores").innerHTML = `
     <div class="card">
       <div class="row wrap">
-        <input data-action="core-subtype" data-c="${coreIndex}" class="small" placeholder="SubtypeId" value="${escapeXml(core.subtypeId)}" />
-        <input data-action="core-unique" data-c="${coreIndex}" class="small" placeholder="UniqueName" value="${escapeXml(core.uniqueName)}" />
-        <select data-action="core-mobility" data-c="${coreIndex}" class="small">
+        <input data-action="core-subtype" data-c="${coreIndex}" class="small" placeholder="SubtypeId" title="Core subtype used by the in-game block and manifest filename mapping." value="${escapeXml(core.subtypeId)}" />
+        <input data-action="core-unique" data-c="${coreIndex}" class="small" placeholder="UniqueName" title="Display name for this core definition." value="${escapeXml(core.uniqueName)}" />
+        <select data-action="core-mobility" data-c="${coreIndex}" class="small" title="Allowed grid mobility for this core: Static, Mobile, or Both.">
           ${["Static", "Mobile", "Both"].map((value) => `<option ${core.mobilityType === value ? "selected" : ""}>${value}</option>`).join("")}
         </select>
         <button data-action="remove-core" data-c="${coreIndex}">Delete Core</button>
@@ -357,7 +357,7 @@ function renderShipCores() {
           </div>
           <div>
             <label>Reusable Block Groups</label>
-            <select data-action="limit-groups" data-c="${coreIndex}" data-l="${limitIndex}" multiple>
+            <select data-action="limit-groups" data-c="${coreIndex}" data-l="${limitIndex}" title="Select one or more reusable block groups to apply to this limit." multiple>
               ${blockGroupOptions(limit.blockGroups)}
             </select>
           </div>

--- a/docs/configurator/app.js
+++ b/docs/configurator/app.js
@@ -1,7 +1,45 @@
 const state = {
   schema: {},
   blockGroups: [],
-  shipCores: []
+  shipCores: [],
+  selectedGroupIndex: 0,
+  selectedCoreIndex: 0
+};
+
+const DEFAULT_GRID_MODIFIERS = {
+  AssemblerSpeed: 1,
+  DrillHarvestMultiplier: 1,
+  GyroEfficiency: 1,
+  GyroForce: 1,
+  PowerProducersOutput: 1,
+  RefineEfficiency: 1,
+  RefineSpeed: 1,
+  ThrusterEfficiency: 1,
+  ThrusterForce: 1
+};
+
+const DEFAULT_SPEED_MODIFIERS = {
+  MaxSpeed: 0.3,
+  MaxBoost: 0.5,
+  BoostDuration: 10,
+  BoostCoolDown: 60,
+  MinimumFrictionSpeedAbsolute: 100,
+  MaximumFrictionSpeedAbsolute: 290,
+  MinimumFrictionSpeedModifier: 0.3,
+  MaximumFrictionSpeedModifier: 0.8,
+  MaximumFrictionDeceleration: 1
+};
+
+const DEFAULT_DEFENSE_MODIFIERS = {
+  Bullet: 1,
+  PostShield: 1,
+  Duration: 0,
+  Cooldown: 0,
+  Rocket: 1,
+  Explosion: 1,
+  Environment: 1,
+  Energy: 1,
+  Kinetic: 1
 };
 
 const ids = (id) => document.getElementById(id);
@@ -57,16 +95,22 @@ function setImportStatus(lines) {
   ids("importStatus").textContent = lines.join("\n");
 }
 
-function addBlockGroup(group = { name: "", blockTypes: [] }) {
-  state.blockGroups.push(group);
-  renderBlockGroups();
-  renderShipCores();
+function parseModifierNode(node, defaults) {
+  const parsed = { ...defaults };
+  if (!node) return parsed;
+
+  Object.keys(defaults).forEach((key) => {
+    parsed[key] = numberOf(node, key, defaults[key]);
+  });
+
+  return parsed;
 }
 
-function addShipCore(core) {
-  state.shipCores.push(core ?? {
+function createDefaultCore() {
+  return {
     subtypeId: "",
     uniqueName: "",
+    originalFileName: "",
     mobilityType: "Both",
     maxBlocks: -1,
     maxMass: -1,
@@ -74,18 +118,49 @@ function addShipCore(core) {
     maxPerPlayer: -1,
     forceBroadcast: false,
     forceBroadcastRange: 2000,
+    speedBoostEnabled: false,
+    speedLimitType: "Normal",
+    enableActiveDefenseModifiers: false,
+    modifiers: { ...DEFAULT_GRID_MODIFIERS },
+    speedModifiers: { ...DEFAULT_SPEED_MODIFIERS },
+    passiveDefenseModifiers: { ...DEFAULT_DEFENSE_MODIFIERS },
+    activeDefenseModifiers: { ...DEFAULT_DEFENSE_MODIFIERS },
     blockLimits: []
-  });
+  };
+}
+
+function ensureValidSelectedIndexes() {
+  state.selectedGroupIndex = state.blockGroups.length
+    ? Math.min(Math.max(state.selectedGroupIndex, 0), state.blockGroups.length - 1)
+    : -1;
+  state.selectedCoreIndex = state.shipCores.length
+    ? Math.min(Math.max(state.selectedCoreIndex, 0), state.shipCores.length - 1)
+    : -1;
+}
+
+function addBlockGroup(group = { name: "", blockTypes: [] }) {
+  state.blockGroups.push(group);
+  state.selectedGroupIndex = state.blockGroups.length - 1;
+  renderBlockGroups();
+  renderShipCores();
+}
+
+function addShipCore(core = createDefaultCore()) {
+  state.shipCores.push({ ...createDefaultCore(), ...core });
+  state.selectedCoreIndex = state.shipCores.length - 1;
   renderShipCores();
 }
 
 function resetEditor(seed = true) {
   state.blockGroups = [];
   state.shipCores = [];
+  state.selectedGroupIndex = 0;
+  state.selectedCoreIndex = 0;
+
   if (seed) {
     addBlockGroup({ name: "Weaponry", blockTypes: [{ typeId: "SmallGatlingGun", subtypeId: "", countWeight: 1 }] });
     addShipCore({
-      subtypeId: "Fighter_Core",
+      subtypeId: "Fighter",
       uniqueName: "Fighter Grid Class",
       mobilityType: "Mobile",
       maxBlocks: 1000,
@@ -94,6 +169,11 @@ function resetEditor(seed = true) {
       maxPerPlayer: 10,
       forceBroadcast: true,
       forceBroadcastRange: 2000,
+      modifiers: {
+        ...DEFAULT_GRID_MODIFIERS,
+        ThrusterForce: 1.15,
+        GyroForce: 1.1
+      },
       blockLimits: [{
         name: "Weapons",
         maxCount: 8,
@@ -107,107 +187,210 @@ function resetEditor(seed = true) {
     renderBlockGroups();
     renderShipCores();
   }
+
   generateXml();
 }
 
-function blockTypeEditor(groupIdx, bt, btIdx) {
+function blockTypeEditor(groupIdx, blockType, blockTypeIdx) {
   return `<div class="row wrap">
-    <input data-action="bt-type" data-g="${groupIdx}" data-i="${btIdx}" class="small" placeholder="TypeId" value="${escapeXml(bt.typeId)}" />
-    <input data-action="bt-subtype" data-g="${groupIdx}" data-i="${btIdx}" class="small" placeholder="SubtypeId (or any)" value="${escapeXml(bt.subtypeId)}" />
-    <input data-action="bt-weight" data-g="${groupIdx}" data-i="${btIdx}" class="small" type="number" step="0.1" value="${bt.countWeight}" />
-    <button data-action="remove-bt" data-g="${groupIdx}" data-i="${btIdx}">Remove BlockType</button>
+    <input data-action="bt-type" data-g="${groupIdx}" data-i="${blockTypeIdx}" class="small" placeholder="TypeId" value="${escapeXml(blockType.typeId)}" />
+    <input data-action="bt-subtype" data-g="${groupIdx}" data-i="${blockTypeIdx}" class="small" placeholder="SubtypeId (or any)" value="${escapeXml(blockType.subtypeId)}" />
+    <input data-action="bt-weight" data-g="${groupIdx}" data-i="${blockTypeIdx}" class="small" type="number" step="0.1" value="${blockType.countWeight}" />
+    <button data-action="remove-bt" data-g="${groupIdx}" data-i="${blockTypeIdx}">Remove BlockType</button>
   </div>`;
 }
 
+function renderGroupSelector() {
+  ensureValidSelectedIndexes();
+  const selector = ids("selectedGroup");
+  selector.innerHTML = state.blockGroups
+    .map((group, idx) => {
+      const label = group.name?.trim() ? `${idx + 1}. ${group.name}` : `${idx + 1}. (Unnamed Group)`;
+      return `<option value="${idx}" ${idx === state.selectedGroupIndex ? "selected" : ""}>${escapeXml(label)}</option>`;
+    })
+    .join("");
+  selector.disabled = state.blockGroups.length === 0;
+}
+
 function renderBlockGroups() {
-  ids("blockGroups").innerHTML = state.blockGroups.map((group, g) => `
+  ensureValidSelectedIndexes();
+  renderGroupSelector();
+
+  if (state.selectedGroupIndex < 0) {
+    ids("blockGroups").innerHTML = `<p class="muted">No block groups yet. Click <strong>Add Block Group</strong>.</p>`;
+    return;
+  }
+
+  const groupIndex = state.selectedGroupIndex;
+  const group = state.blockGroups[groupIndex];
+
+  ids("blockGroups").innerHTML = `
     <div class="card">
-      <h4>Group ${g + 1}</h4>
+      <h4>Group ${groupIndex + 1} of ${state.blockGroups.length}</h4>
       <div class="row wrap">
-        <input data-action="group-name" data-g="${g}" placeholder="Group Name" value="${escapeXml(group.name)}" />
-        <button data-action="add-bt" data-g="${g}">Add BlockType</button>
-        <button data-action="remove-group" data-g="${g}">Delete Group</button>
+        <input data-action="group-name" data-g="${groupIndex}" placeholder="Group Name" value="${escapeXml(group.name)}" />
+        <button data-action="add-bt" data-g="${groupIndex}">Add BlockType</button>
+        <button data-action="remove-group" data-g="${groupIndex}">Delete Group</button>
       </div>
-      ${group.blockTypes.map((bt, i) => blockTypeEditor(g, bt, i)).join("")}
+      ${group.blockTypes.map((bt, i) => blockTypeEditor(groupIndex, bt, i)).join("")}
     </div>
-  `).join("");
+  `;
 }
 
 function blockGroupOptions(selected = []) {
   return state.blockGroups
-    .filter((g) => g.name.trim())
-    .map((g) => `<option value="${escapeXml(g.name)}" ${selected.includes(g.name) ? "selected" : ""}>${escapeXml(g.name)}</option>`)
+    .filter((group) => group.name.trim())
+    .map((group) => `<option value="${escapeXml(group.name)}" ${selected.includes(group.name) ? "selected" : ""}>${escapeXml(group.name)}</option>`)
     .join("");
 }
 
+function modifierFieldColumn({ title, fields, action, step = 0.01, dataAttrs = "" }) {
+  return `
+    <div class="modifier-column card">
+      <h5>${escapeXml(title)}</h5>
+      ${fields
+        .map((field) => `<label class="modifier-field">${escapeXml(field.name)}<input data-action="${action}" ${dataAttrs} data-m="${field.name}" class="small" type="number" step="${step}" value="${field.value}" /></label>`)
+        .join("")}
+    </div>
+  `;
+}
+
+function mapModifierFields(values, defaults) {
+  return Object.keys(defaults).map((name) => ({
+    name,
+    value: Number(values?.[name] ?? defaults[name])
+  }));
+}
+
+function renderCoreSelector() {
+  ensureValidSelectedIndexes();
+  const selector = ids("selectedCore");
+  selector.innerHTML = state.shipCores
+    .map((core, idx) => {
+      const label = core.subtypeId?.trim() || "Unnamed Core";
+      return `<option value="${idx}" ${idx === state.selectedCoreIndex ? "selected" : ""}>${escapeXml(`${idx + 1}. ${label}`)}</option>`;
+    })
+    .join("");
+  selector.disabled = state.shipCores.length === 0;
+}
+
 function renderShipCores() {
-  ids("shipCores").innerHTML = state.shipCores.map((core, c) => `
+  ensureValidSelectedIndexes();
+  renderCoreSelector();
+
+  if (state.selectedCoreIndex < 0) {
+    ids("shipCores").innerHTML = `<p class="muted">No ship cores yet. Click <strong>Add Ship Core</strong>.</p>`;
+    return;
+  }
+
+  const coreIndex = state.selectedCoreIndex;
+  const core = state.shipCores[coreIndex];
+
+  ids("shipCores").innerHTML = `
     <div class="card">
-      <h4>Core ${c + 1}</h4>
+      <h4>Core ${coreIndex + 1} of ${state.shipCores.length}</h4>
       <div class="row wrap">
-        <input data-action="core-subtype" data-c="${c}" class="small" placeholder="SubtypeId" value="${escapeXml(core.subtypeId)}" />
-        <input data-action="core-unique" data-c="${c}" class="small" placeholder="UniqueName" value="${escapeXml(core.uniqueName)}" />
-        <select data-action="core-mobility" data-c="${c}" class="small">
-          ${["Static", "Mobile", "Both"].map((v) => `<option ${core.mobilityType === v ? "selected" : ""}>${v}</option>`).join("")}
+        <input data-action="core-subtype" data-c="${coreIndex}" class="small" placeholder="SubtypeId" value="${escapeXml(core.subtypeId)}" />
+        <input data-action="core-unique" data-c="${coreIndex}" class="small" placeholder="UniqueName" value="${escapeXml(core.uniqueName)}" />
+        <select data-action="core-mobility" data-c="${coreIndex}" class="small">
+          ${["Static", "Mobile", "Both"].map((value) => `<option ${core.mobilityType === value ? "selected" : ""}>${value}</option>`).join("")}
         </select>
-        <button data-action="remove-core" data-c="${c}">Delete Core</button>
+        <button data-action="remove-core" data-c="${coreIndex}">Delete Core</button>
       </div>
       <div class="row wrap">
-        <label class="inline">MaxBlocks <input data-action="core-maxblocks" data-c="${c}" class="small" type="number" value="${core.maxBlocks}" /></label>
-        <label class="inline">MaxMass <input data-action="core-maxmass" data-c="${c}" class="small" type="number" value="${core.maxMass}" /></label>
-        <label class="inline">MaxPCU <input data-action="core-maxpcu" data-c="${c}" class="small" type="number" value="${core.maxPcu}" /></label>
-        <label class="inline">MaxPerPlayer <input data-action="core-maxpp" data-c="${c}" class="small" type="number" value="${core.maxPerPlayer}" /></label>
+        <label class="inline">MaxBlocks <input data-action="core-maxblocks" data-c="${coreIndex}" class="small" type="number" value="${core.maxBlocks}" /></label>
+        <label class="inline">MaxMass <input data-action="core-maxmass" data-c="${coreIndex}" class="small" type="number" value="${core.maxMass}" /></label>
+        <label class="inline">MaxPCU <input data-action="core-maxpcu" data-c="${coreIndex}" class="small" type="number" value="${core.maxPcu}" /></label>
+        <label class="inline">MaxPerPlayer <input data-action="core-maxpp" data-c="${coreIndex}" class="small" type="number" value="${core.maxPerPlayer}" /></label>
       </div>
       <div class="row wrap">
-        <label class="inline">ForceBroadcast <input data-action="core-fb" data-c="${c}" type="checkbox" ${core.forceBroadcast ? "checked" : ""} /></label>
-        <label class="inline">BroadcastRange <input data-action="core-fbr" data-c="${c}" class="small" type="number" value="${core.forceBroadcastRange}" /></label>
-        <button data-action="add-limit" data-c="${c}">Add Block Limit</button>
+        <label class="inline">ForceBroadcast <input data-action="core-fb" data-c="${coreIndex}" type="checkbox" ${core.forceBroadcast ? "checked" : ""}/></label>
+        <label class="inline">BroadcastRange <input data-action="core-fbr" data-c="${coreIndex}" class="small" type="number" value="${core.forceBroadcastRange}" /></label>
+        <label class="inline">SpeedBoostEnabled <input data-action="core-speedboost" data-c="${coreIndex}" type="checkbox" ${core.speedBoostEnabled ? "checked" : ""}/></label>
+        <label class="inline">EnableActiveDefense <input data-action="core-enable-active-defense" data-c="${coreIndex}" type="checkbox" ${core.enableActiveDefenseModifiers ? "checked" : ""}/></label>
+        <label class="inline">SpeedLimitType
+          <select data-action="core-speed-limit-type" data-c="${coreIndex}" class="small">
+            ${["Normal", "Friction"].map((value) => `<option ${core.speedLimitType === value ? "selected" : ""}>${value}</option>`).join("")}
+          </select>
+        </label>
+        <button data-action="add-limit" data-c="${coreIndex}">Add Block Limit</button>
       </div>
-      ${core.blockLimits.map((limit, l) => `
+
+      <div class="modifier-row four-columns">
+        ${modifierFieldColumn({
+          title: "Grid Modifiers",
+          action: "core-modifier-grid",
+          dataAttrs: `data-c="${coreIndex}"`,
+          fields: mapModifierFields(core.modifiers, DEFAULT_GRID_MODIFIERS)
+        })}
+        ${modifierFieldColumn({
+          title: "Speed Modifiers",
+          action: "core-modifier-speed",
+          dataAttrs: `data-c="${coreIndex}"`,
+          fields: mapModifierFields(core.speedModifiers, DEFAULT_SPEED_MODIFIERS)
+        })}
+        ${modifierFieldColumn({
+          title: "Passive Defense Modifiers",
+          action: "core-modifier-passive-defense",
+          dataAttrs: `data-c="${coreIndex}"`,
+          fields: mapModifierFields(core.passiveDefenseModifiers, DEFAULT_DEFENSE_MODIFIERS)
+        })}
+        ${modifierFieldColumn({
+          title: "Active Defense Modifiers",
+          action: "core-modifier-active-defense",
+          dataAttrs: `data-c="${coreIndex}"`,
+          fields: mapModifierFields(core.activeDefenseModifiers, DEFAULT_DEFENSE_MODIFIERS)
+        })}
+      </div>
+
+      ${core.blockLimits.map((limit, limitIndex) => `
         <div class="card">
           <div class="row wrap">
-            <input data-action="limit-name" data-c="${c}" data-l="${l}" class="small" placeholder="Limit Name" value="${escapeXml(limit.name)}" />
-            <label class="inline">MaxCount <input data-action="limit-max" data-c="${c}" data-l="${l}" class="small" type="number" step="0.1" value="${limit.maxCount}" /></label>
-            <button data-action="remove-limit" data-c="${c}" data-l="${l}">Delete Limit</button>
+            <input data-action="limit-name" data-c="${coreIndex}" data-l="${limitIndex}" class="small" placeholder="Limit Name" value="${escapeXml(limit.name)}" />
+            <label class="inline">MaxCount <input data-action="limit-max" data-c="${coreIndex}" data-l="${limitIndex}" class="small" type="number" step="0.1" value="${limit.maxCount}" /></label>
+            <button data-action="remove-limit" data-c="${coreIndex}" data-l="${limitIndex}">Delete Limit</button>
           </div>
           <div class="row wrap">
-            <label class="inline">PunishByNoFlyZone <input data-action="limit-punish" data-c="${c}" data-l="${l}" type="checkbox" ${limit.punishByNoFlyZone ? "checked" : ""}/></label>
-            <select data-action="limit-type" data-c="${c}" data-l="${l}" class="small">
-              ${["ShutOff", "Damage", "Delete", "Explode"].map((v) => `<option ${limit.punishmentType === v ? "selected" : ""}>${v}</option>`).join("")}
+            <label class="inline">PunishByNoFlyZone <input data-action="limit-punish" data-c="${coreIndex}" data-l="${limitIndex}" type="checkbox" ${limit.punishByNoFlyZone ? "checked" : ""}/></label>
+            <select data-action="limit-type" data-c="${coreIndex}" data-l="${limitIndex}" class="small">
+              ${["ShutOff", "Damage", "Delete", "Explode"].map((value) => `<option ${limit.punishmentType === value ? "selected" : ""}>${value}</option>`).join("")}
             </select>
-            <input data-action="limit-dir" data-c="${c}" data-l="${l}" class="small" placeholder="AllowedDirections csv (Forward,Up)" value="${escapeXml((limit.allowedDirections || []).join(","))}" />
+            <input data-action="limit-dir" data-c="${coreIndex}" data-l="${limitIndex}" class="small" placeholder="AllowedDirections csv (Forward,Up)" value="${escapeXml((limit.allowedDirections || []).join(","))}" />
           </div>
           <div>
             <label>Reusable Block Groups</label>
-            <select data-action="limit-groups" data-c="${c}" data-l="${l}" multiple>
+            <select data-action="limit-groups" data-c="${coreIndex}" data-l="${limitIndex}" multiple>
               ${blockGroupOptions(limit.blockGroups)}
             </select>
           </div>
         </div>
       `).join("")}
     </div>
-  `).join("");
+  `;
 }
 
 function parseGroupsXml(text) {
   const doc = parseXml(text);
-  const groups = Array.from(doc.querySelectorAll("BlockGroup")).map((groupNode) => ({
-    name: textOf(groupNode, "Name"),
-    blockTypes: Array.from(groupNode.querySelectorAll(":scope > BlockTypes")).map((typeNode) => ({
-      typeId: textOf(typeNode, "TypeId"),
-      subtypeId: textOf(typeNode, "SubtypeId"),
-      countWeight: numberOf(typeNode, "CountWeight", 1)
+  return Array.from(doc.querySelectorAll("BlockGroup"))
+    .map((groupNode) => ({
+      name: textOf(groupNode, "Name"),
+      blockTypes: Array.from(groupNode.querySelectorAll(":scope > BlockTypes")).map((typeNode) => ({
+        typeId: textOf(typeNode, "TypeId"),
+        subtypeId: textOf(typeNode, "SubtypeId"),
+        countWeight: numberOf(typeNode, "CountWeight", 1)
+      }))
     }))
-  })).filter((group) => group.name);
-  return groups;
+    .filter((group) => group.name);
 }
 
-function parseCoreXml(text) {
+function parseCoreXml(text, originalFileName = "") {
   const doc = parseXml(text);
   const coreNode = doc.querySelector("ShipCore");
   if (!coreNode) return null;
 
   return {
+    ...createDefaultCore(),
+    originalFileName,
     subtypeId: textOf(coreNode, "SubtypeId"),
     uniqueName: textOf(coreNode, "UniqueName"),
     mobilityType: textOf(coreNode, "MobilityType") || "Both",
@@ -217,6 +400,13 @@ function parseCoreXml(text) {
     maxPerPlayer: numberOf(coreNode, "MaxPerPlayer", -1),
     forceBroadcast: boolOf(coreNode, "ForceBroadCast", false),
     forceBroadcastRange: numberOf(coreNode, "ForceBroadCastRange", 2000),
+    speedBoostEnabled: boolOf(coreNode, "SpeedBoostEnabled", false),
+    speedLimitType: textOf(coreNode, "SpeedLimitType") || "Normal",
+    enableActiveDefenseModifiers: boolOf(coreNode, "EnableActiveDefenseModifiers", false),
+    modifiers: parseModifierNode(coreNode.querySelector(":scope > Modifiers"), DEFAULT_GRID_MODIFIERS),
+    speedModifiers: parseModifierNode(coreNode.querySelector(":scope > SpeedModifiers"), DEFAULT_SPEED_MODIFIERS),
+    passiveDefenseModifiers: parseModifierNode(coreNode.querySelector(":scope > PassiveDefenseModifiers"), DEFAULT_DEFENSE_MODIFIERS),
+    activeDefenseModifiers: parseModifierNode(coreNode.querySelector(":scope > ActiveDefenseModifiers"), DEFAULT_DEFENSE_MODIFIERS),
     blockLimits: Array.from(coreNode.querySelectorAll(":scope > BlockLimits")).map((limitNode) => ({
       name: textOf(limitNode, "Name"),
       maxCount: numberOf(limitNode, "MaxCount", 0),
@@ -228,25 +418,134 @@ function parseCoreXml(text) {
   };
 }
 
-function generateXml() {
-  const header = '<?xml version="1.0" encoding="UTF-8"?>';
-  const groups = `${header}\n<ArrayOfBlockGroup>\n${state.blockGroups.map((g) => `  <BlockGroup>\n    <Name>${escapeXml(g.name)}</Name>\n${g.blockTypes.map((bt) => `    <BlockTypes>\n      <TypeId>${escapeXml(bt.typeId)}</TypeId>\n      <SubtypeId>${escapeXml(bt.subtypeId || "")}</SubtypeId>\n      <CountWeight>${bt.countWeight}</CountWeight>\n    </BlockTypes>`).join("\n")}\n  </BlockGroup>`).join("\n")}\n</ArrayOfBlockGroup>`;
-
-  const manifest = `${header}\n<CoreManifest>\n${state.shipCores.filter((core) => core.subtypeId.trim()).map((core) => `  <ShipCoreFilenames>Data/Cores/${escapeXml(core.subtypeId)}.xml</ShipCoreFilenames>`).join("\n")}\n</CoreManifest>`;
-
-  const cores = state.shipCores.map((core) => ({
-    file: `${core.subtypeId || "UnnamedCore"}.xml`,
-    body: `${header}\n<ShipCore>\n  <SubtypeId>${escapeXml(core.subtypeId)}</SubtypeId>\n  <UniqueName>${escapeXml(core.uniqueName)}</UniqueName>\n  <ForceBroadCast>${core.forceBroadcast}</ForceBroadCast>\n  <ForceBroadCastRange>${core.forceBroadcastRange}</ForceBroadCastRange>\n  <MobilityType>${escapeXml(core.mobilityType)}</MobilityType>\n  <MaxBlocks>${core.maxBlocks}</MaxBlocks>\n  <MaxMass>${core.maxMass}</MaxMass>\n  <MaxPCU>${core.maxPcu}</MaxPCU>\n  <MaxPerPlayer>${core.maxPerPlayer}</MaxPerPlayer>\n${core.blockLimits.map((limit) => `  <BlockLimits>\n    <Name>${escapeXml(limit.name)}</Name>\n${limit.blockGroups.map((g) => `    <BlockGroups>${escapeXml(g)}</BlockGroups>`).join("\n")}\n    <MaxCount>${limit.maxCount}</MaxCount>\n    <PunishByNoFlyZone>${limit.punishByNoFlyZone}</PunishByNoFlyZone>\n    <PunishmentType>${escapeXml(limit.punishmentType)}</PunishmentType>\n${(limit.allowedDirections || []).filter(Boolean).map((d) => `    <AllowedDirections>${escapeXml(d)}</AllowedDirections>`).join("\n")}\n  </BlockLimits>`).join("\n")}\n</ShipCore>`
-  }));
-
-  ids("groupsXml").textContent = groups;
-  ids("manifestXml").textContent = manifest;
-  ids("coresXml").textContent = cores.map((c) => `===== ${c.file} =====\n${c.body}`).join("\n\n");
-  return { groups, manifest, cores };
+function writeModifierXml(tag, values, defaults, indent = "  ") {
+  return `${indent}<${tag}>\n${Object.keys(defaults)
+    .map((name) => `${indent}  <${name}>${Number(values?.[name] ?? defaults[name])}</${name}>`)
+    .join("\n")}\n${indent}</${tag}>`;
 }
 
-function download(filename, content) {
-  const blob = new Blob([content], { type: "application/xml" });
+function sanitizeFilenamePart(value) {
+  return String(value ?? "")
+    .trim()
+    .replace(/\s+/g, "_")
+    .replace(/[^a-zA-Z0-9_-]/g, "")
+    .replace(/^_+|_+$/g, "");
+}
+
+function deriveCoreFilename(core) {
+  if (core.originalFileName?.trim()) return core.originalFileName.trim();
+
+  const base = sanitizeFilenamePart(core.subtypeId || core.uniqueName || "unnamed");
+  const withoutSuffix = base.replace(/_core$/i, "");
+  return `${withoutSuffix || "unnamed"}_core.xml`;
+}
+
+function createCrc32Table() {
+  const table = new Uint32Array(256);
+  for (let i = 0; i < 256; i += 1) {
+    let crc = i;
+    for (let j = 0; j < 8; j += 1) {
+      crc = (crc & 1) ? (0xedb88320 ^ (crc >>> 1)) : (crc >>> 1);
+    }
+    table[i] = crc >>> 0;
+  }
+  return table;
+}
+
+const CRC32_TABLE = createCrc32Table();
+
+function crc32(bytes) {
+  let crc = 0xffffffff;
+  for (let i = 0; i < bytes.length; i += 1) {
+    crc = CRC32_TABLE[(crc ^ bytes[i]) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function dosDateTime(date = new Date()) {
+  const year = Math.max(1980, date.getFullYear());
+  const dosTime = (date.getSeconds() >> 1) | (date.getMinutes() << 5) | (date.getHours() << 11);
+  const dosDate = date.getDate() | ((date.getMonth() + 1) << 5) | ((year - 1980) << 9);
+  return { dosTime, dosDate };
+}
+
+function pushUint16(buffer, value) {
+  buffer.push(value & 0xff, (value >>> 8) & 0xff);
+}
+
+function pushUint32(buffer, value) {
+  buffer.push(value & 0xff, (value >>> 8) & 0xff, (value >>> 16) & 0xff, (value >>> 24) & 0xff);
+}
+
+function createZip(entries) {
+  const encoder = new TextEncoder();
+  const localParts = [];
+  const centralParts = [];
+  let localOffset = 0;
+  const { dosTime, dosDate } = dosDateTime();
+
+  for (const entry of entries) {
+    const nameBytes = encoder.encode(entry.name);
+    const dataBytes = encoder.encode(entry.content);
+    const crc = crc32(dataBytes);
+
+    const localHeader = [];
+    pushUint32(localHeader, 0x04034b50);
+    pushUint16(localHeader, 20);
+    pushUint16(localHeader, 0);
+    pushUint16(localHeader, 0);
+    pushUint16(localHeader, dosTime);
+    pushUint16(localHeader, dosDate);
+    pushUint32(localHeader, crc);
+    pushUint32(localHeader, dataBytes.length);
+    pushUint32(localHeader, dataBytes.length);
+    pushUint16(localHeader, nameBytes.length);
+    pushUint16(localHeader, 0);
+
+    const localHeaderBytes = new Uint8Array(localHeader);
+    localParts.push(localHeaderBytes, nameBytes, dataBytes);
+
+    const centralHeader = [];
+    pushUint32(centralHeader, 0x02014b50);
+    pushUint16(centralHeader, 20);
+    pushUint16(centralHeader, 20);
+    pushUint16(centralHeader, 0);
+    pushUint16(centralHeader, 0);
+    pushUint16(centralHeader, dosTime);
+    pushUint16(centralHeader, dosDate);
+    pushUint32(centralHeader, crc);
+    pushUint32(centralHeader, dataBytes.length);
+    pushUint32(centralHeader, dataBytes.length);
+    pushUint16(centralHeader, nameBytes.length);
+    pushUint16(centralHeader, 0);
+    pushUint16(centralHeader, 0);
+    pushUint16(centralHeader, 0);
+    pushUint16(centralHeader, 0);
+    pushUint32(centralHeader, 0);
+    pushUint32(centralHeader, localOffset);
+
+    const centralHeaderBytes = new Uint8Array(centralHeader);
+    centralParts.push(centralHeaderBytes, nameBytes);
+
+    localOffset += localHeaderBytes.length + nameBytes.length + dataBytes.length;
+  }
+
+  const centralSize = centralParts.reduce((sum, part) => sum + part.length, 0);
+  const centralOffset = localOffset;
+  const endRecord = [];
+  pushUint32(endRecord, 0x06054b50);
+  pushUint16(endRecord, 0);
+  pushUint16(endRecord, 0);
+  pushUint16(endRecord, entries.length);
+  pushUint16(endRecord, entries.length);
+  pushUint32(endRecord, centralSize);
+  pushUint32(endRecord, centralOffset);
+  pushUint16(endRecord, 0);
+
+  return new Blob([...localParts, ...centralParts, new Uint8Array(endRecord)], { type: "application/zip" });
+}
+
+function downloadBlob(filename, blob) {
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
@@ -255,23 +554,60 @@ function download(filename, content) {
   URL.revokeObjectURL(url);
 }
 
+function download(filename, content) {
+  downloadBlob(filename, new Blob([content], { type: "application/xml" }));
+}
+
+function generateXml() {
+  const header = '<?xml version="1.0" encoding="UTF-8"?>';
+
+  const groups = `${header}\n<ArrayOfBlockGroup>\n${state.blockGroups
+    .map((group) => `  <BlockGroup>\n    <Name>${escapeXml(group.name)}</Name>\n${group.blockTypes
+      .map((bt) => `    <BlockTypes>\n      <TypeId>${escapeXml(bt.typeId)}</TypeId>\n      <SubtypeId>${escapeXml(bt.subtypeId || "")}</SubtypeId>\n      <CountWeight>${bt.countWeight}</CountWeight>\n    </BlockTypes>`)
+      .join("\n")}\n  </BlockGroup>`)
+    .join("\n")}\n</ArrayOfBlockGroup>`;
+
+  const manifest = `${header}\n<CoreManifest>\n${state.shipCores
+    .filter((core) => core.subtypeId.trim())
+    .map((core) => `  <ShipCoreFilenames>Data/Cores/${escapeXml(deriveCoreFilename(core))}</ShipCoreFilenames>`)
+    .join("\n")}\n</CoreManifest>`;
+
+  const cores = state.shipCores.map((core) => ({
+    file: deriveCoreFilename(core),
+    body: `${header}\n<ShipCore>\n  <SubtypeId>${escapeXml(core.subtypeId)}</SubtypeId>\n  <UniqueName>${escapeXml(core.uniqueName)}</UniqueName>\n  <ForceBroadCast>${core.forceBroadcast}</ForceBroadCast>\n  <ForceBroadCastRange>${core.forceBroadcastRange}</ForceBroadCastRange>\n  <MobilityType>${escapeXml(core.mobilityType)}</MobilityType>\n  <MaxBlocks>${core.maxBlocks}</MaxBlocks>\n  <MaxMass>${core.maxMass}</MaxMass>\n  <MaxPCU>${core.maxPcu}</MaxPCU>\n  <MaxPerPlayer>${core.maxPerPlayer}</MaxPerPlayer>\n  <SpeedBoostEnabled>${core.speedBoostEnabled}</SpeedBoostEnabled>\n  <SpeedLimitType>${escapeXml(core.speedLimitType)}</SpeedLimitType>\n  <EnableActiveDefenseModifiers>${core.enableActiveDefenseModifiers}</EnableActiveDefenseModifiers>\n${writeModifierXml("Modifiers", core.modifiers, DEFAULT_GRID_MODIFIERS)}\n${writeModifierXml("SpeedModifiers", core.speedModifiers, DEFAULT_SPEED_MODIFIERS)}\n${writeModifierXml("PassiveDefenseModifiers", core.passiveDefenseModifiers, DEFAULT_DEFENSE_MODIFIERS)}\n${writeModifierXml("ActiveDefenseModifiers", core.activeDefenseModifiers, DEFAULT_DEFENSE_MODIFIERS)}\n${core.blockLimits
+      .map((limit) => `  <BlockLimits>\n    <Name>${escapeXml(limit.name)}</Name>\n${limit.blockGroups.map((g) => `    <BlockGroups>${escapeXml(g)}</BlockGroups>`).join("\n")}\n    <MaxCount>${limit.maxCount}</MaxCount>\n    <PunishByNoFlyZone>${limit.punishByNoFlyZone}</PunishByNoFlyZone>\n    <PunishmentType>${escapeXml(limit.punishmentType)}</PunishmentType>\n${(limit.allowedDirections || []).filter(Boolean).map((d) => `    <AllowedDirections>${escapeXml(d)}</AllowedDirections>`).join("\n")}\n  </BlockLimits>`)
+      .join("\n")}\n</ShipCore>`
+  }));
+
+  ids("groupsXml").textContent = groups;
+  ids("manifestXml").textContent = manifest;
+  ids("coresXml").textContent = cores.map((core) => `===== ${core.file} =====\n${core.body}`).join("\n\n");
+  return { groups, manifest, cores };
+}
+
 document.addEventListener("click", (event) => {
   const target = event.target;
   if (!(target instanceof HTMLElement)) return;
   const action = target.dataset.action;
   if (!action) return;
 
-  const g = Number(target.dataset.g);
-  const i = Number(target.dataset.i);
-  const c = Number(target.dataset.c);
-  const l = Number(target.dataset.l);
+  const groupIndex = Number(target.dataset.g);
+  const blockTypeIndex = Number(target.dataset.i);
+  const coreIndex = Number(target.dataset.c);
+  const limitIndex = Number(target.dataset.l);
 
-  if (action === "add-bt") state.blockGroups[g].blockTypes.push({ typeId: "", subtypeId: "", countWeight: 1 });
-  if (action === "remove-bt") state.blockGroups[g].blockTypes.splice(i, 1);
-  if (action === "remove-group") state.blockGroups.splice(g, 1);
-  if (action === "remove-core") state.shipCores.splice(c, 1);
-  if (action === "add-limit") state.shipCores[c].blockLimits.push({ name: "", maxCount: 0, punishByNoFlyZone: false, punishmentType: "ShutOff", allowedDirections: [], blockGroups: [] });
-  if (action === "remove-limit") state.shipCores[c].blockLimits.splice(l, 1);
+  if (action === "add-bt") state.blockGroups[groupIndex].blockTypes.push({ typeId: "", subtypeId: "", countWeight: 1 });
+  if (action === "remove-bt") state.blockGroups[groupIndex].blockTypes.splice(blockTypeIndex, 1);
+  if (action === "remove-group") {
+    state.blockGroups.splice(groupIndex, 1);
+    if (state.selectedGroupIndex >= state.blockGroups.length) state.selectedGroupIndex = state.blockGroups.length - 1;
+  }
+  if (action === "remove-core") {
+    state.shipCores.splice(coreIndex, 1);
+    if (state.selectedCoreIndex >= state.shipCores.length) state.selectedCoreIndex = state.shipCores.length - 1;
+  }
+  if (action === "add-limit") state.shipCores[coreIndex].blockLimits.push({ name: "", maxCount: 0, punishByNoFlyZone: false, punishmentType: "ShutOff", allowedDirections: [], blockGroups: [] });
+  if (action === "remove-limit") state.shipCores[coreIndex].blockLimits.splice(limitIndex, 1);
 
   renderBlockGroups();
   renderShipCores();
@@ -283,39 +619,67 @@ document.addEventListener("input", (event) => {
   const action = target.dataset.action;
   if (!action) return;
 
-  const g = Number(target.dataset.g);
-  const i = Number(target.dataset.i);
-  const c = Number(target.dataset.c);
-  const l = Number(target.dataset.l);
+  const groupIndex = Number(target.dataset.g);
+  const blockTypeIndex = Number(target.dataset.i);
+  const coreIndex = Number(target.dataset.c);
+  const limitIndex = Number(target.dataset.l);
 
-  if (action === "group-name") state.blockGroups[g].name = target.value;
-  if (action === "bt-type") state.blockGroups[g].blockTypes[i].typeId = target.value;
-  if (action === "bt-subtype") state.blockGroups[g].blockTypes[i].subtypeId = target.value;
-  if (action === "bt-weight") state.blockGroups[g].blockTypes[i].countWeight = Number(target.value || 0);
+  if (action === "group-name") state.blockGroups[groupIndex].name = target.value;
+  if (action === "bt-type") state.blockGroups[groupIndex].blockTypes[blockTypeIndex].typeId = target.value;
+  if (action === "bt-subtype") state.blockGroups[groupIndex].blockTypes[blockTypeIndex].subtypeId = target.value;
+  if (action === "bt-weight") state.blockGroups[groupIndex].blockTypes[blockTypeIndex].countWeight = Number(target.value || 0);
 
-  if (action === "core-subtype") state.shipCores[c].subtypeId = target.value;
-  if (action === "core-unique") state.shipCores[c].uniqueName = target.value;
-  if (action === "core-maxblocks") state.shipCores[c].maxBlocks = Number(target.value || -1);
-  if (action === "core-maxmass") state.shipCores[c].maxMass = Number(target.value || -1);
-  if (action === "core-maxpcu") state.shipCores[c].maxPcu = Number(target.value || -1);
-  if (action === "core-maxpp") state.shipCores[c].maxPerPlayer = Number(target.value || -1);
-  if (action === "core-fbr") state.shipCores[c].forceBroadcastRange = Number(target.value || 0);
+  if (action === "core-subtype") {
+    state.shipCores[coreIndex].subtypeId = target.value;
+    if (!state.shipCores[coreIndex].originalFileName) renderShipCores();
+  }
+  if (action === "core-unique") state.shipCores[coreIndex].uniqueName = target.value;
+  if (action === "core-maxblocks") state.shipCores[coreIndex].maxBlocks = Number(target.value || -1);
+  if (action === "core-maxmass") state.shipCores[coreIndex].maxMass = Number(target.value || -1);
+  if (action === "core-maxpcu") state.shipCores[coreIndex].maxPcu = Number(target.value || -1);
+  if (action === "core-maxpp") state.shipCores[coreIndex].maxPerPlayer = Number(target.value || -1);
+  if (action === "core-fbr") state.shipCores[coreIndex].forceBroadcastRange = Number(target.value || 0);
 
-  if (action === "limit-name") state.shipCores[c].blockLimits[l].name = target.value;
-  if (action === "limit-max") state.shipCores[c].blockLimits[l].maxCount = Number(target.value || 0);
-  if (action === "limit-dir") state.shipCores[c].blockLimits[l].allowedDirections = target.value.split(",").map((v) => v.trim()).filter(Boolean);
+  if (action === "core-modifier-grid") state.shipCores[coreIndex].modifiers[target.dataset.m] = Number(target.value || 0);
+  if (action === "core-modifier-speed") state.shipCores[coreIndex].speedModifiers[target.dataset.m] = Number(target.value || 0);
+  if (action === "core-modifier-passive-defense") state.shipCores[coreIndex].passiveDefenseModifiers[target.dataset.m] = Number(target.value || 0);
+  if (action === "core-modifier-active-defense") state.shipCores[coreIndex].activeDefenseModifiers[target.dataset.m] = Number(target.value || 0);
+
+  if (action === "limit-name") state.shipCores[coreIndex].blockLimits[limitIndex].name = target.value;
+  if (action === "limit-max") state.shipCores[coreIndex].blockLimits[limitIndex].maxCount = Number(target.value || 0);
+  if (action === "limit-dir") state.shipCores[coreIndex].blockLimits[limitIndex].allowedDirections = target.value.split(",").map((v) => v.trim()).filter(Boolean);
+
+  if (action === "group-name" || action === "core-subtype") {
+    renderBlockGroups();
+    renderShipCores();
+  }
 });
 
 document.addEventListener("change", (event) => {
   const target = event.target;
   if (!(target instanceof HTMLElement)) return;
   const action = target.dataset.action;
+  const coreIndex = Number(target.dataset.c);
+  const limitIndex = Number(target.dataset.l);
 
-  if (action === "core-fb") state.shipCores[Number(target.dataset.c)].forceBroadcast = target.checked;
-  if (action === "core-mobility") state.shipCores[Number(target.dataset.c)].mobilityType = target.value;
-  if (action === "limit-punish") state.shipCores[Number(target.dataset.c)].blockLimits[Number(target.dataset.l)].punishByNoFlyZone = target.checked;
-  if (action === "limit-type") state.shipCores[Number(target.dataset.c)].blockLimits[Number(target.dataset.l)].punishmentType = target.value;
-  if (action === "limit-groups") state.shipCores[Number(target.dataset.c)].blockLimits[Number(target.dataset.l)].blockGroups = Array.from(target.selectedOptions).map((o) => o.value);
+  if (action === "core-fb") state.shipCores[coreIndex].forceBroadcast = target.checked;
+  if (action === "core-mobility") state.shipCores[coreIndex].mobilityType = target.value;
+  if (action === "core-speedboost") state.shipCores[coreIndex].speedBoostEnabled = target.checked;
+  if (action === "core-enable-active-defense") state.shipCores[coreIndex].enableActiveDefenseModifiers = target.checked;
+  if (action === "core-speed-limit-type") state.shipCores[coreIndex].speedLimitType = target.value;
+  if (action === "limit-punish") state.shipCores[coreIndex].blockLimits[limitIndex].punishByNoFlyZone = target.checked;
+  if (action === "limit-type") state.shipCores[coreIndex].blockLimits[limitIndex].punishmentType = target.value;
+  if (action === "limit-groups") state.shipCores[coreIndex].blockLimits[limitIndex].blockGroups = Array.from(target.selectedOptions).map((o) => o.value);
+});
+
+ids("selectedGroup").addEventListener("change", (event) => {
+  state.selectedGroupIndex = Number(event.target.value);
+  renderBlockGroups();
+});
+
+ids("selectedCore").addEventListener("change", (event) => {
+  state.selectedCoreIndex = Number(event.target.value);
+  renderShipCores();
 });
 
 ids("addGroup").addEventListener("click", () => addBlockGroup({ name: "", blockTypes: [] }));
@@ -330,7 +694,8 @@ ids("downloadGroups").addEventListener("click", () => download("ShipCoreConfig_G
 ids("downloadManifest").addEventListener("click", () => download("ShipCoreConfig_Manifest.xml", generateXml().manifest));
 ids("downloadCores").addEventListener("click", () => {
   const xml = generateXml();
-  download("ShipCore_Cores_Bundle.txt", xml.cores.map((c) => `### ${c.file}\n${c.body}`).join("\n\n"));
+  const zip = createZip(xml.cores.map((core) => ({ name: core.file, content: core.body })));
+  downloadBlob("ShipCore_XMLs.zip", zip);
 });
 
 ids("loadUploadedXml").addEventListener("click", async () => {
@@ -349,6 +714,7 @@ ids("loadUploadedXml").addEventListener("click", async () => {
   if (groupsFile) {
     const groups = parseGroupsXml(await groupsFile.text());
     state.blockGroups = groups;
+    state.selectedGroupIndex = 0;
     status.push(`Loaded ${groups.length} block groups from ${groupsFile.name}.`);
   }
 
@@ -359,7 +725,7 @@ ids("loadUploadedXml").addEventListener("click", async () => {
   }
 
   for (const file of coreFiles) {
-    const parsed = parseCoreXml(await file.text());
+    const parsed = parseCoreXml(await file.text(), file.name);
     if (!parsed) {
       status.push(`Skipped ${file.name}: no <ShipCore> root found.`);
       continue;
@@ -368,13 +734,10 @@ ids("loadUploadedXml").addEventListener("click", async () => {
     status.push(`Loaded core '${parsed.subtypeId || file.name}'.`);
   }
 
-  if (state.blockGroups.length === 0) {
-    status.push("No block groups loaded (you can still create them manually).");
-  }
+  state.selectedCoreIndex = 0;
 
-  if (state.shipCores.length === 0) {
-    status.push("No cores loaded (you can still add cores manually).");
-  }
+  if (state.blockGroups.length === 0) status.push("No block groups loaded (you can still create them manually).");
+  if (state.shipCores.length === 0) status.push("No cores loaded (you can still add cores manually).");
 
   renderBlockGroups();
   renderShipCores();

--- a/docs/configurator/app.js
+++ b/docs/configurator/app.js
@@ -226,7 +226,6 @@ function renderBlockGroups() {
 
   ids("blockGroups").innerHTML = `
     <div class="card">
-      <h4>Group ${groupIndex + 1} of ${state.blockGroups.length}</h4>
       <div class="row wrap">
         <input data-action="group-name" data-g="${groupIndex}" placeholder="Group Name" value="${escapeXml(group.name)}" />
         <button data-action="add-bt" data-g="${groupIndex}">Add BlockType</button>
@@ -288,7 +287,6 @@ function renderShipCores() {
 
   ids("shipCores").innerHTML = `
     <div class="card">
-      <h4>Core ${coreIndex + 1} of ${state.shipCores.length}</h4>
       <div class="row wrap">
         <input data-action="core-subtype" data-c="${coreIndex}" class="small" placeholder="SubtypeId" value="${escapeXml(core.subtypeId)}" />
         <input data-action="core-unique" data-c="${coreIndex}" class="small" placeholder="UniqueName" value="${escapeXml(core.uniqueName)}" />

--- a/docs/configurator/app.js
+++ b/docs/configurator/app.js
@@ -193,9 +193,9 @@ function resetEditor(seed = true) {
 
 function blockTypeEditor(groupIdx, blockType, blockTypeIdx) {
   return `<div class="row wrap">
-    <input data-action="bt-type" data-g="${groupIdx}" data-i="${blockTypeIdx}" class="small" placeholder="TypeId" title="Block TypeId. Example: SmallGatlingGun." value="${escapeXml(blockType.typeId)}" />
-    <input data-action="bt-subtype" data-g="${groupIdx}" data-i="${blockTypeIdx}" class="small" placeholder="SubtypeId (or any)" title="Optional block subtype filter. Use &quot;any&quot; to match all subtypes." value="${escapeXml(blockType.subtypeId)}" />
-    <input data-action="bt-weight" data-g="${groupIdx}" data-i="${blockTypeIdx}" class="small" type="number" step="0.1" title="Weight contribution for matching blocks in this group." value="${blockType.countWeight}" />
+    <label class="inline">TypeId <input data-action="bt-type" data-g="${groupIdx}" data-i="${blockTypeIdx}" class="small" placeholder="TypeId" value="${escapeXml(blockType.typeId)}" /></label>
+    <label class="inline">SubtypeId <input data-action="bt-subtype" data-g="${groupIdx}" data-i="${blockTypeIdx}" class="small" placeholder="SubtypeId (or any)" value="${escapeXml(blockType.subtypeId)}" /></label>
+    <label class="inline">CountWeight <input data-action="bt-weight" data-g="${groupIdx}" data-i="${blockTypeIdx}" class="small" type="number" step="0.1" value="${blockType.countWeight}" /></label>
     <button data-action="remove-bt" data-g="${groupIdx}" data-i="${blockTypeIdx}">Remove BlockType</button>
   </div>`;
 }
@@ -227,7 +227,7 @@ function renderBlockGroups() {
   ids("blockGroups").innerHTML = `
     <div class="card">
       <div class="row wrap">
-        <input data-action="group-name" data-g="${groupIndex}" placeholder="Group Name" title="Reusable block group name referenced by block limits." value="${escapeXml(group.name)}" />
+        <label class="inline">Group Name <input data-action="group-name" data-g="${groupIndex}" placeholder="Group Name" value="${escapeXml(group.name)}" /></label>
         <button data-action="add-bt" data-g="${groupIndex}">Add BlockType</button>
         <button data-action="remove-group" data-g="${groupIndex}">Delete Group</button>
       </div>
@@ -288,11 +288,13 @@ function renderShipCores() {
   ids("shipCores").innerHTML = `
     <div class="card">
       <div class="row wrap">
-        <input data-action="core-subtype" data-c="${coreIndex}" class="small" placeholder="SubtypeId" title="Core subtype used by the in-game block and manifest filename mapping." value="${escapeXml(core.subtypeId)}" />
-        <input data-action="core-unique" data-c="${coreIndex}" class="small" placeholder="UniqueName" title="Display name for this core definition." value="${escapeXml(core.uniqueName)}" />
-        <select data-action="core-mobility" data-c="${coreIndex}" class="small" title="Allowed grid mobility for this core: Static, Mobile, or Both.">
-          ${["Static", "Mobile", "Both"].map((value) => `<option ${core.mobilityType === value ? "selected" : ""}>${value}</option>`).join("")}
-        </select>
+        <label class="inline">Core Subtype <input data-action="core-subtype" data-c="${coreIndex}" class="small" placeholder="SubtypeId" value="${escapeXml(core.subtypeId)}" /></label>
+        <label class="inline">Core Name <input data-action="core-unique" data-c="${coreIndex}" class="small" placeholder="UniqueName" value="${escapeXml(core.uniqueName)}" /></label>
+        <label class="inline">Mobility
+          <select data-action="core-mobility" data-c="${coreIndex}" class="small">
+            ${["Static", "Mobile", "Both"].map((value) => `<option ${core.mobilityType === value ? "selected" : ""}>${value}</option>`).join("")}
+          </select>
+        </label>
         <button data-action="remove-core" data-c="${coreIndex}">Delete Core</button>
       </div>
       <div class="row wrap">
@@ -357,7 +359,7 @@ function renderShipCores() {
           </div>
           <div>
             <label>Reusable Block Groups</label>
-            <select data-action="limit-groups" data-c="${coreIndex}" data-l="${limitIndex}" title="Select one or more reusable block groups to apply to this limit." multiple>
+            <select data-action="limit-groups" data-c="${coreIndex}" data-l="${limitIndex}" multiple>
               ${blockGroupOptions(limit.blockGroups)}
             </select>
           </div>

--- a/docs/configurator/index.html
+++ b/docs/configurator/index.html
@@ -23,7 +23,7 @@
     <section class="panel">
       <h2>2) Renovate Existing XML (optional)</h2>
       <p class="muted">Upload existing XML files. Recognized tags are loaded into the editor; unknown tags are ignored.</p>
-      <div class="row wrap">
+      <div class="row wrap file-upload-row">
         <label class="file-label">Groups XML
           <input id="groupsXmlFile" type="file" accept=".xml" />
         </label>
@@ -43,13 +43,19 @@
 
     <section class="panel">
       <h2>3) Reusable Block Groups</h2>
-      <button id="addGroup">Add Block Group</button>
+      <div class="menu-controls">
+        <button id="addGroup">Add Block Group</button>
+        <select id="selectedGroup" aria-label="Selected Group"></select>
+      </div>
       <div id="blockGroups"></div>
     </section>
 
     <section class="panel">
       <h2>4) Ship Cores</h2>
-      <button id="addCore">Add Ship Core</button>
+      <div class="menu-controls">
+        <button id="addCore">Add Ship Core</button>
+        <select id="selectedCore" aria-label="Selected Core"></select>
+      </div>
       <div id="shipCores"></div>
     </section>
 
@@ -59,7 +65,7 @@
         <button id="generateXml">Generate</button>
         <button id="downloadGroups">Download ShipCoreConfig_Groups.xml</button>
         <button id="downloadManifest">Download ShipCoreConfig_Manifest.xml</button>
-        <button id="downloadCores">Download all ShipCore XMLs (.zip-like text bundle)</button>
+        <button id="downloadCores">Download all ShipCore XMLs (.zip)</button>
       </div>
       <h3>ShipCoreConfig_Groups.xml</h3>
       <pre id="groupsXml" class="code-block"></pre>

--- a/docs/configurator/styles.css
+++ b/docs/configurator/styles.css
@@ -1,10 +1,15 @@
 :root {
+  /* keep sizing predictable so inputs stay inside cards/labels */
   color-scheme: dark;
   --bg: #111827;
   --panel: #1f2937;
   --text: #e5e7eb;
   --muted: #9ca3af;
 }
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
   font-family: Inter, system-ui, sans-serif;
@@ -12,7 +17,7 @@ body {
   color: var(--text);
 }
 header, main {
-  max-width: 1100px;
+  max-width: 1900px;
   margin: 0 auto;
   padding: 1rem;
 }
@@ -33,9 +38,22 @@ textarea, input, select {
   background: #111827;
   color: var(--text);
 }
+.file-upload-row {
+  gap: 1rem;
+  margin-bottom: 0.85rem;
+}
 .file-label {
-  min-width: 240px;
+  min-width: 260px;
   flex: 1;
+  padding: 0.35rem 0.45rem 0.2rem;
+  border: 1px solid #374151;
+  border-radius: 8px;
+  background: #0f172a;
+}
+.file-label input {
+  display: block;
+  width: 100%;
+  margin-top: 0.45rem;
 }
 button {
   background: #0f766e;
@@ -64,4 +82,37 @@ button:hover { background: #0d9488; }
 .card h4 { margin: 0.25rem 0 0.5rem; }
 .small { width: 220px; }
 .inline { display: inline-flex; gap: 0.5rem; align-items: center; margin-right: 1rem; }
+.menu-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.65rem;
+}
+.menu-controls select {
+  min-width: 320px;
+  max-width: 520px;
+  margin: 0;
+}
+.modifier-row {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0.75rem 0;
+}
+.four-columns {
+  grid-template-columns: repeat(4, minmax(240px, 1fr));
+}
+.modifier-column h5 {
+  margin: 0 0 0.5rem;
+}
+.modifier-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  margin-bottom: 0.5rem;
+  padding: 0 0.35rem;
+}
+.modifier-field input {
+  width: 100%;
+  min-width: 0;
+}
 .muted { color: var(--muted); }


### PR DESCRIPTION
### Motivation
- Fix inconsistent left/right padding in modifier entry controls and ensure file selection inputs remain visually contained inside their labeled card boxes.
- Make the Ship Core editor more robust by adding selection controls, sane defaults for modifier groups, and improved import/export behavior.

### Description
- CSS: added global `box-sizing: border-box`, introduced `.file-upload-row`, made `.file-label` a card with `padding` and set `.file-label input` to `display: block; width: 100%`, and added symmetric horizontal padding to `.modifier-field` so inputs fill the padded area.
- UI/state: extended `state` with `selectedGroupIndex` and `selectedCoreIndex`, added `createDefaultCore()` and default modifier sets (`DEFAULT_*_MODIFIERS`), and ensured selected indexes are validated via `ensureValidSelectedIndexes()`.
- Rendering: added group/core selectors and related rendering helpers (`renderGroupSelector`, `renderCoreSelector`, `modifierFieldColumn`, `mapModifierFields`) and updated `renderBlockGroups()` and `renderShipCores()` to show the selected item and modifier columns.
- Parsing/generation: added `parseModifierNode`, extended `parseCoreXml` to import modifiers and extra flags, added `writeModifierXml` and `deriveCoreFilename` for stable filenames, and replaced the cores bundle text download with a real ZIP creator (`createZip`, `downloadBlob`) using an internal CRC32 implementation.
- Events: updated event handlers to use explicit index variables (`groupIndex`, `coreIndex`, etc.), wire the new modifier input actions (`core-modifier-*`) and selection changes for `selectedGroup`/`selectedCore`.

### Testing
- Started a local static server with `python3 -m http.server 4173` and verified the app served successfully (succeeded).
- Captured a Playwright screenshot of `http://127.0.0.1:4173/index.html` to validate spacing, containment, and the updated configurator layout (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ce048d5008323a2177e075bc553f8)