### PR TITLE
Use checkboxes for reusable block groups and auto-regenerate XML on edits

### DIFF
--- a/docs/configurator/app.js
+++ b/docs/configurator/app.js
@@ -236,13 +236,15 @@ function renderBlockGroups() {
   `;
 }
 
-function blockGroupOptions(selected = []) {
+function blockGroupCheckboxes(coreIndex, limitIndex, selected = []) {
   return state.blockGroups
     .filter((group) => group.name.trim())
-    .map((group) => `<option value="${escapeXml(group.name)}" ${selected.includes(group.name) ? "selected" : ""}>${escapeXml(group.name)}</option>`)
+    .map((group) => `<label class="group-checklist-item">
+      <input data-action="limit-group-toggle" data-c="${coreIndex}" data-l="${limitIndex}" data-group-name="${escapeXml(group.name)}" type="checkbox" ${selected.includes(group.name) ? "checked" : ""} />
+      <span>${escapeXml(group.name)}</span>
+    </label>`)
     .join("");
 }
-
 function modifierFieldColumn({ title, fields, action, step = 0.01, dataAttrs = "" }) {
   return `
     <div class="modifier-column card">
@@ -359,9 +361,9 @@ function renderShipCores() {
           </div>
           <div>
             <label>Reusable Block Groups</label>
-            <select data-action="limit-groups" data-c="${coreIndex}" data-l="${limitIndex}" multiple>
-              ${blockGroupOptions(limit.blockGroups)}
-            </select>
+            <div class="group-checklist">
+              ${blockGroupCheckboxes(coreIndex, limitIndex, limit.blockGroups)}
+            </div>
           </div>
         </div>
       `).join("")}
@@ -611,6 +613,7 @@ document.addEventListener("click", (event) => {
 
   renderBlockGroups();
   renderShipCores();
+  generateXml();
 });
 
 document.addEventListener("input", (event) => {
@@ -653,6 +656,8 @@ document.addEventListener("input", (event) => {
     renderBlockGroups();
     renderShipCores();
   }
+
+  generateXml();
 });
 
 document.addEventListener("change", (event) => {
@@ -669,17 +674,31 @@ document.addEventListener("change", (event) => {
   if (action === "core-speed-limit-type") state.shipCores[coreIndex].speedLimitType = target.value;
   if (action === "limit-punish") state.shipCores[coreIndex].blockLimits[limitIndex].punishByNoFlyZone = target.checked;
   if (action === "limit-type") state.shipCores[coreIndex].blockLimits[limitIndex].punishmentType = target.value;
-  if (action === "limit-groups") state.shipCores[coreIndex].blockLimits[limitIndex].blockGroups = Array.from(target.selectedOptions).map((o) => o.value);
+  if (action === "limit-group-toggle") {
+    const limit = state.shipCores[coreIndex].blockLimits[limitIndex];
+    const groupName = target.dataset.groupName || "";
+    if (!groupName) return;
+
+    const selectedSet = new Set(limit.blockGroups || []);
+    if (target.checked) selectedSet.add(groupName);
+    else selectedSet.delete(groupName);
+    limit.blockGroups = Array.from(selectedSet);
+    renderShipCores();
+  }
+
+  generateXml();
 });
 
 ids("selectedGroup").addEventListener("change", (event) => {
   state.selectedGroupIndex = Number(event.target.value);
   renderBlockGroups();
+  generateXml();
 });
 
 ids("selectedCore").addEventListener("change", (event) => {
   state.selectedCoreIndex = Number(event.target.value);
   renderShipCores();
+  generateXml();
 });
 
 ids("addGroup").addEventListener("click", () => addBlockGroup({ name: "", blockTypes: [] }));

--- a/docs/configurator/styles.css
+++ b/docs/configurator/styles.css
@@ -116,3 +116,20 @@ button:hover { background: #0d9488; }
   min-width: 0;
 }
 .muted { color: var(--muted); }
+
+.group-checklist {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.35rem 0.75rem;
+  margin-top: 0.35rem;
+}
+.group-checklist-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.2rem 0;
+}
+.group-checklist-item input {
+  width: auto;
+  margin: 0;
+}


### PR DESCRIPTION
### Motivation
- Replace the multi-select block-group UI with per-limit checkboxes so reusable block groups are assigned via explicit toggles as requested. 
- Ensure edits are immediately persisted to the generated XML so switching between cores/groups shows the latest changes in section 5 output. 

### Description
- Removed the reusable block-group multi-select and the `blockGroupOptions` path and render only per-group checkboxes in `docs/configurator/app.js` (checkbox markup produced by `blockGroupCheckboxes`).
- Wire checkbox toggles to update each limit's `blockGroups` (`data-action="limit-group-toggle"`) and rebuild the UI after changes so limit assignments stay in sync. 
- Call `generateXml()` after click/input/change events and when switching `selectedGroup`/`selectedCore` so the XML output is regenerated immediately on every edit. 
- Added styles for `.group-checklist` and `.group-checklist-item` in `docs/configurator/styles.css` to match the editor layout. 

### Testing
- Ran `node --check docs/configurator/app.js` and the syntax check succeeded. 
- Served the configurator via `python3 -m http.server` and ran a Playwright smoke test that edited a core subtype, added/switched cores, and toggled a reusable-group checkbox; all assertions (immediate XML update on edit, persistence across switching, and removal of `<BlockGroups>` when a group checkbox is unchecked) passed. 
- Confirmed the UI renders correctly with checkbox-only group controls and no runtime errors observed during testing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cee93682083238b50e4cfd3fea329)