### PR TITLE
Fix limit checkbox updates; add 6 direction toggles and field titles

### DIFF
--- a/docs/configurator/app.js
+++ b/docs/configurator/app.js
@@ -42,6 +42,9 @@ const DEFAULT_DEFENSE_MODIFIERS = {
   Kinetic: 1
 };
 
+
+const VALID_DIRECTIONS = ["Forward", "Backward", "Up", "Down", "Left", "Right"];
+
 const ids = (id) => document.getElementById(id);
 
 function escapeXml(value) {
@@ -236,10 +239,22 @@ function renderBlockGroups() {
   `;
 }
 
-function blockGroupOptions(selected = []) {
+function blockGroupCheckboxes(coreIndex, limitIndex, selected = []) {
   return state.blockGroups
     .filter((group) => group.name.trim())
-    .map((group) => `<option value="${escapeXml(group.name)}" ${selected.includes(group.name) ? "selected" : ""}>${escapeXml(group.name)}</option>`)
+    .map((group) => `<label class="group-checklist-item">
+      <input data-action="limit-group-toggle" data-c="${coreIndex}" data-l="${limitIndex}" data-group-name="${escapeXml(group.name)}" type="checkbox" ${selected.includes(group.name) ? "checked" : ""} />
+      <span>${escapeXml(group.name)}</span>
+    </label>`)
+    .join("");
+}
+
+function directionCheckboxes(coreIndex, limitIndex, selected = []) {
+  return VALID_DIRECTIONS
+    .map((direction) => `<label class="group-checklist-item">
+      <input data-action="limit-direction-toggle" data-c="${coreIndex}" data-l="${limitIndex}" data-direction="${escapeXml(direction)}" type="checkbox" ${selected.includes(direction) ? "checked" : ""} />
+      <span>${escapeXml(direction)}</span>
+    </label>`)
     .join("");
 }
 
@@ -352,16 +367,23 @@ function renderShipCores() {
           </div>
           <div class="row wrap">
             <label class="inline">PunishByNoFlyZone <input data-action="limit-punish" data-c="${coreIndex}" data-l="${limitIndex}" type="checkbox" ${limit.punishByNoFlyZone ? "checked" : ""}/></label>
-            <select data-action="limit-type" data-c="${coreIndex}" data-l="${limitIndex}" class="small">
-              ${["ShutOff", "Damage", "Delete", "Explode"].map((value) => `<option ${limit.punishmentType === value ? "selected" : ""}>${value}</option>`).join("")}
-            </select>
-            <input data-action="limit-dir" data-c="${coreIndex}" data-l="${limitIndex}" class="small" placeholder="AllowedDirections csv (Forward,Up)" value="${escapeXml((limit.allowedDirections || []).join(","))}" />
+            <label class="inline">Punishment Type
+              <select data-action="limit-type" data-c="${coreIndex}" data-l="${limitIndex}" class="small">
+                ${["ShutOff", "Damage", "Delete", "Explode"].map((value) => `<option ${limit.punishmentType === value ? "selected" : ""}>${value}</option>`).join("")}
+              </select>
+            </label>
+          </div>
+          <div>
+            <label>Valid Directions</label>
+            <div class="group-checklist">
+              ${directionCheckboxes(coreIndex, limitIndex, limit.allowedDirections || [])}
+            </div>
           </div>
           <div>
             <label>Reusable Block Groups</label>
-            <select data-action="limit-groups" data-c="${coreIndex}" data-l="${limitIndex}" multiple>
-              ${blockGroupOptions(limit.blockGroups)}
-            </select>
+            <div class="group-checklist">
+              ${blockGroupCheckboxes(coreIndex, limitIndex, limit.blockGroups)}
+            </div>
           </div>
         </div>
       `).join("")}
@@ -595,22 +617,40 @@ document.addEventListener("click", (event) => {
   const blockTypeIndex = Number(target.dataset.i);
   const coreIndex = Number(target.dataset.c);
   const limitIndex = Number(target.dataset.l);
+  let didMutate = false;
 
-  if (action === "add-bt") state.blockGroups[groupIndex].blockTypes.push({ typeId: "", subtypeId: "", countWeight: 1 });
-  if (action === "remove-bt") state.blockGroups[groupIndex].blockTypes.splice(blockTypeIndex, 1);
+  if (action === "add-bt") {
+    state.blockGroups[groupIndex].blockTypes.push({ typeId: "", subtypeId: "", countWeight: 1 });
+    didMutate = true;
+  }
+  if (action === "remove-bt") {
+    state.blockGroups[groupIndex].blockTypes.splice(blockTypeIndex, 1);
+    didMutate = true;
+  }
   if (action === "remove-group") {
     state.blockGroups.splice(groupIndex, 1);
     if (state.selectedGroupIndex >= state.blockGroups.length) state.selectedGroupIndex = state.blockGroups.length - 1;
+    didMutate = true;
   }
   if (action === "remove-core") {
     state.shipCores.splice(coreIndex, 1);
     if (state.selectedCoreIndex >= state.shipCores.length) state.selectedCoreIndex = state.shipCores.length - 1;
+    didMutate = true;
   }
-  if (action === "add-limit") state.shipCores[coreIndex].blockLimits.push({ name: "", maxCount: 0, punishByNoFlyZone: false, punishmentType: "ShutOff", allowedDirections: [], blockGroups: [] });
-  if (action === "remove-limit") state.shipCores[coreIndex].blockLimits.splice(limitIndex, 1);
+  if (action === "add-limit") {
+    state.shipCores[coreIndex].blockLimits.push({ name: "", maxCount: 0, punishByNoFlyZone: false, punishmentType: "ShutOff", allowedDirections: [], blockGroups: [] });
+    didMutate = true;
+  }
+  if (action === "remove-limit") {
+    state.shipCores[coreIndex].blockLimits.splice(limitIndex, 1);
+    didMutate = true;
+  }
+
+  if (!didMutate) return;
 
   renderBlockGroups();
   renderShipCores();
+  generateXml();
 });
 
 document.addEventListener("input", (event) => {
@@ -647,12 +687,13 @@ document.addEventListener("input", (event) => {
 
   if (action === "limit-name") state.shipCores[coreIndex].blockLimits[limitIndex].name = target.value;
   if (action === "limit-max") state.shipCores[coreIndex].blockLimits[limitIndex].maxCount = Number(target.value || 0);
-  if (action === "limit-dir") state.shipCores[coreIndex].blockLimits[limitIndex].allowedDirections = target.value.split(",").map((v) => v.trim()).filter(Boolean);
 
   if (action === "group-name" || action === "core-subtype") {
     renderBlockGroups();
     renderShipCores();
   }
+
+  generateXml();
 });
 
 document.addEventListener("change", (event) => {
@@ -662,24 +703,58 @@ document.addEventListener("change", (event) => {
   const coreIndex = Number(target.dataset.c);
   const limitIndex = Number(target.dataset.l);
 
-  if (action === "core-fb") state.shipCores[coreIndex].forceBroadcast = target.checked;
-  if (action === "core-mobility") state.shipCores[coreIndex].mobilityType = target.value;
-  if (action === "core-speedboost") state.shipCores[coreIndex].speedBoostEnabled = target.checked;
-  if (action === "core-enable-active-defense") state.shipCores[coreIndex].enableActiveDefenseModifiers = target.checked;
-  if (action === "core-speed-limit-type") state.shipCores[coreIndex].speedLimitType = target.value;
-  if (action === "limit-punish") state.shipCores[coreIndex].blockLimits[limitIndex].punishByNoFlyZone = target.checked;
-  if (action === "limit-type") state.shipCores[coreIndex].blockLimits[limitIndex].punishmentType = target.value;
-  if (action === "limit-groups") state.shipCores[coreIndex].blockLimits[limitIndex].blockGroups = Array.from(target.selectedOptions).map((o) => o.value);
+  const inputElement = target instanceof HTMLInputElement ? target : null;
+  const selectElement = target instanceof HTMLSelectElement ? target : null;
+
+  if (action === "core-fb" && inputElement) state.shipCores[coreIndex].forceBroadcast = inputElement.checked;
+  if (action === "core-mobility" && selectElement) state.shipCores[coreIndex].mobilityType = selectElement.value;
+  if (action === "core-speedboost" && inputElement) state.shipCores[coreIndex].speedBoostEnabled = inputElement.checked;
+  if (action === "core-enable-active-defense" && inputElement) state.shipCores[coreIndex].enableActiveDefenseModifiers = inputElement.checked;
+  if (action === "core-speed-limit-type" && selectElement) state.shipCores[coreIndex].speedLimitType = selectElement.value;
+  if (action === "limit-punish" && inputElement) {
+    state.shipCores[coreIndex].blockLimits[limitIndex].punishByNoFlyZone = inputElement.checked;
+    renderShipCores();
+  }
+  if (action === "limit-type" && selectElement) {
+    state.shipCores[coreIndex].blockLimits[limitIndex].punishmentType = selectElement.value;
+    renderShipCores();
+  }
+  if (action === "limit-direction-toggle" && inputElement) {
+    const limit = state.shipCores[coreIndex].blockLimits[limitIndex];
+    const direction = inputElement.dataset.direction || "";
+    if (!direction) return;
+
+    const selectedSet = new Set(limit.allowedDirections || []);
+    if (inputElement.checked) selectedSet.add(direction);
+    else selectedSet.delete(direction);
+    limit.allowedDirections = VALID_DIRECTIONS.filter((value) => selectedSet.has(value));
+    renderShipCores();
+  }
+  if (action === "limit-group-toggle" && inputElement) {
+    const limit = state.shipCores[coreIndex].blockLimits[limitIndex];
+    const groupName = inputElement.dataset.groupName || "";
+    if (!groupName) return;
+
+    const selectedSet = new Set(limit.blockGroups || []);
+    if (inputElement.checked) selectedSet.add(groupName);
+    else selectedSet.delete(groupName);
+    limit.blockGroups = Array.from(selectedSet);
+    renderShipCores();
+  }
+
+  generateXml();
 });
 
 ids("selectedGroup").addEventListener("change", (event) => {
   state.selectedGroupIndex = Number(event.target.value);
   renderBlockGroups();
+  generateXml();
 });
 
 ids("selectedCore").addEventListener("change", (event) => {
   state.selectedCoreIndex = Number(event.target.value);
   renderShipCores();
+  generateXml();
 });
 
 ids("addGroup").addEventListener("click", () => addBlockGroup({ name: "", blockTypes: [] }));

--- a/docs/configurator/styles.css
+++ b/docs/configurator/styles.css
@@ -116,3 +116,20 @@ button:hover { background: #0d9488; }
   min-width: 0;
 }
 .muted { color: var(--muted); }
+
+.group-checklist {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.35rem 0.75rem;
+  margin-top: 0.35rem;
+}
+.group-checklist-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.2rem 0;
+}
+.group-checklist-item input {
+  width: auto;
+  margin: 0;
+}


### PR DESCRIPTION
### Motivation
- Checkbox interactions inside block limits were not reliably mutating state or updating generated XML, so immediate UI toggles needed restoration.
- Replace the fragile CSV-based directions editor with explicit toggles for all valid directions to make configuration clearer and less error-prone.
- Add field titles to clarify the `Punishment Type` and `Valid Directions` controls within each limit.

### Description
- Added `VALID_DIRECTIONS` and a `directionCheckboxes(coreIndex, limitIndex, selected)` renderer and replaced the old `limit-dir` CSV input with per-direction checkboxes. (modified `docs/configurator/app.js`).
- Replaced the previous reusable-group multi-select with `blockGroupCheckboxes(coreIndex, limitIndex, selected)` that renders per-limit checkbox items and kept the groups UI in the limits. (modified `docs/configurator/app.js`).
- Hardened event handling by making the global `change` handler type-aware (distinguishing `HTMLInputElement` and `HTMLSelectElement`), added explicit handlers for `limit-punish`, `limit-type`, `limit-direction-toggle`, and `limit-group-toggle`, and ensured immediate `renderShipCores()` / `generateXml()` where appropriate. (modified `docs/configurator/app.js`).
- Made the global `click` handler only perform structural mutations using a `didMutate` guard so non-structural clicks (like checkbox toggles) return early and do not cause unnecessary re-renders. (modified `docs/configurator/app.js`).
- Added layout styles for `.group-checklist` and `.group-checklist-item` to match the editor layout. (modified `docs/configurator/styles.css`).

### Testing
- Ran `node --check docs/configurator/app.js` and the syntax check succeeded. 
- Served the configurator with `python3 -m http.server 4173` and the server started successfully. 
- Executed a Playwright smoke script that toggled `PunishByNoFlyZone`, toggled a direction checkbox (`Forward`), and toggled a reusable block-group checkbox, asserting that each toggle updated both the UI and the generated XML; all assertions passed and a screenshot artifact was saved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cee93682083238b50e4cfd3fea329)