### PR TITLE
Fix block group name input and auto-sync block-limit group references

### DIFF
--- a/docs/configurator/app.js
+++ b/docs/configurator/app.js
@@ -148,6 +148,26 @@ function addBlockGroup(group = { name: "", blockTypes: [] }) {
   renderShipCores();
 }
 
+function renameBlockGroupReferences(previousName, nextName) {
+  if (!previousName || previousName === nextName) return;
+  state.shipCores.forEach((core) => {
+    core.blockLimits.forEach((limit) => {
+      if (!Array.isArray(limit.blockGroups)) return;
+      limit.blockGroups = limit.blockGroups.map((groupName) => (groupName === previousName ? nextName : groupName));
+    });
+  });
+}
+
+function removeBlockGroupReferences(groupNameToRemove) {
+  if (!groupNameToRemove) return;
+  state.shipCores.forEach((core) => {
+    core.blockLimits.forEach((limit) => {
+      if (!Array.isArray(limit.blockGroups)) return;
+      limit.blockGroups = limit.blockGroups.filter((groupName) => groupName !== groupNameToRemove);
+    });
+  });
+}
+
 function addShipCore(core = createDefaultCore()) {
   state.shipCores.push({ ...createDefaultCore(), ...core });
   state.selectedCoreIndex = state.shipCores.length - 1;
@@ -627,6 +647,8 @@ document.addEventListener("click", (event) => {
     didMutate = true;
   }
   if (action === "remove-group") {
+    const removedGroupName = state.blockGroups[groupIndex]?.name || "";
+    removeBlockGroupReferences(removedGroupName);
     state.blockGroups.splice(groupIndex, 1);
     if (state.selectedGroupIndex >= state.blockGroups.length) state.selectedGroupIndex = state.blockGroups.length - 1;
     didMutate = true;
@@ -663,7 +685,11 @@ document.addEventListener("input", (event) => {
   const coreIndex = Number(target.dataset.c);
   const limitIndex = Number(target.dataset.l);
 
-  if (action === "group-name") state.blockGroups[groupIndex].name = target.value;
+  if (action === "group-name") {
+    const previousName = state.blockGroups[groupIndex].name;
+    state.blockGroups[groupIndex].name = target.value;
+    renameBlockGroupReferences(previousName, target.value);
+  }
   if (action === "bt-type") state.blockGroups[groupIndex].blockTypes[blockTypeIndex].typeId = target.value;
   if (action === "bt-subtype") state.blockGroups[groupIndex].blockTypes[blockTypeIndex].subtypeId = target.value;
   if (action === "bt-weight") state.blockGroups[groupIndex].blockTypes[blockTypeIndex].countWeight = Number(target.value || 0);
@@ -687,8 +713,12 @@ document.addEventListener("input", (event) => {
   if (action === "limit-name") state.shipCores[coreIndex].blockLimits[limitIndex].name = target.value;
   if (action === "limit-max") state.shipCores[coreIndex].blockLimits[limitIndex].maxCount = Number(target.value || 0);
 
-  if (action === "group-name" || action === "core-subtype") {
-    renderBlockGroups();
+  if (action === "group-name") {
+    renderGroupSelector();
+    renderShipCores();
+  }
+
+  if (action === "core-subtype") {
     renderShipCores();
   }
 


### PR DESCRIPTION
### Motivation
- Typing into the block group name input re-rendered the entire block-group panel on every keystroke which caused the UI to accept only one character at a time. 
- Block limits on ship cores could hold stale references when a block group was renamed or deleted, so the available group list for cores/limits needed to stay in sync automatically.

### Description
- Stop full block-group panel re-renders on each `group-name` keystroke by only updating the selector and cores view during typing via `renderGroupSelector()` and `renderShipCores()` instead of `renderBlockGroups()`; this preserves the active input and fixes the one-character input issue (`docs/configurator/app.js`).
- Add `renameBlockGroupReferences(previousName, nextName)` to update `blockLimits[].blockGroups` when a group is renamed (`docs/configurator/app.js`).
- Add `removeBlockGroupReferences(groupNameToRemove)` and call it before removing a group so cores/limits drop deleted group names (`docs/configurator/app.js`).
- Update click/input handlers to call the new helper functions and adjust render calls accordingly so cores and selectors reflect live changes without resetting inputs (`docs/configurator/app.js`).

### Testing
- Ran `node --check docs/configurator/app.js` which succeeded with no syntax errors. 
- Attempted an automated UI snapshot using Playwright against `docs/configurator/index.html`, but Chromium crashed (SIGSEGV) in this environment so no screenshot could be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cfc71bef8832386555d024c8827c7)