### PR TITLE
Defer XML configurator group/core text updates until blur or Enter

### DIFF
--- a/docs/configurator/app.js
+++ b/docs/configurator/app.js
@@ -685,19 +685,10 @@ document.addEventListener("input", (event) => {
   const coreIndex = Number(target.dataset.c);
   const limitIndex = Number(target.dataset.l);
 
-  if (action === "group-name") {
-    const previousName = state.blockGroups[groupIndex].name;
-    state.blockGroups[groupIndex].name = target.value;
-    renameBlockGroupReferences(previousName, target.value);
-  }
   if (action === "bt-type") state.blockGroups[groupIndex].blockTypes[blockTypeIndex].typeId = target.value;
   if (action === "bt-subtype") state.blockGroups[groupIndex].blockTypes[blockTypeIndex].subtypeId = target.value;
   if (action === "bt-weight") state.blockGroups[groupIndex].blockTypes[blockTypeIndex].countWeight = Number(target.value || 0);
 
-  if (action === "core-subtype") {
-    state.shipCores[coreIndex].subtypeId = target.value;
-    if (!state.shipCores[coreIndex].originalFileName) renderShipCores();
-  }
   if (action === "core-unique") state.shipCores[coreIndex].uniqueName = target.value;
   if (action === "core-maxblocks") state.shipCores[coreIndex].maxBlocks = Number(target.value || -1);
   if (action === "core-maxmass") state.shipCores[coreIndex].maxMass = Number(target.value || -1);
@@ -713,16 +704,49 @@ document.addEventListener("input", (event) => {
   if (action === "limit-name") state.shipCores[coreIndex].blockLimits[limitIndex].name = target.value;
   if (action === "limit-max") state.shipCores[coreIndex].blockLimits[limitIndex].maxCount = Number(target.value || 0);
 
+  generateXml();
+});
+
+function commitDeferredTextInput(target) {
+  if (!(target instanceof HTMLInputElement)) return;
+
+  const action = target.dataset.action;
+  const groupIndex = Number(target.dataset.g);
+  const coreIndex = Number(target.dataset.c);
+
   if (action === "group-name") {
+    const previousName = state.blockGroups[groupIndex].name;
+    const nextName = target.value;
+    if (previousName === nextName) return;
+
+    state.blockGroups[groupIndex].name = nextName;
+    renameBlockGroupReferences(previousName, nextName);
     renderGroupSelector();
     renderShipCores();
+    generateXml();
   }
 
   if (action === "core-subtype") {
-    renderShipCores();
-  }
+    const previousSubtype = state.shipCores[coreIndex].subtypeId;
+    const nextSubtype = target.value;
+    if (previousSubtype === nextSubtype) return;
 
-  generateXml();
+    state.shipCores[coreIndex].subtypeId = nextSubtype;
+    renderShipCores();
+    generateXml();
+  }
+}
+
+document.addEventListener("keydown", (event) => {
+  if (event.key !== "Enter") return;
+
+  const target = event.target;
+  if (!(target instanceof HTMLInputElement)) return;
+
+  const action = target.dataset.action;
+  if (action !== "group-name" && action !== "core-subtype") return;
+
+  target.blur();
 });
 
 document.addEventListener("change", (event) => {
@@ -734,6 +758,11 @@ document.addEventListener("change", (event) => {
 
   const inputElement = target instanceof HTMLInputElement ? target : null;
   const selectElement = target instanceof HTMLSelectElement ? target : null;
+
+  if (action === "group-name" || action === "core-subtype") {
+    commitDeferredTextInput(target);
+    return;
+  }
 
   if (action === "core-fb" && inputElement) state.shipCores[coreIndex].forceBroadcast = inputElement.checked;
   if (action === "core-mobility" && selectElement) state.shipCores[coreIndex].mobilityType = selectElement.value;


### PR DESCRIPTION
### Motivation

- Typing in the XML configurator's `Group Name` and `Core Subtype` inputs was being committed on every keystroke which caused re-renders and forced the input to lose focus while editing. 
- The intent is to allow users to type freely and only apply changes when they explicitly finish editing (blur/deselect or press Enter). 
- Other fields should continue to live-update as before to preserve immediate feedback where it makes sense.

### Description

- Stop updating `group-name` and `core-subtype` on each `input` event and add a deferred commit function `commitDeferredTextInput` that applies those two fields only when editing is committed. 
- Ensure committing `group-name` performs reference renaming via `renameBlockGroupReferences`, re-renders group selectors and cores, and regenerates the XML, and ensure committing `core-subtype` re-renders cores and regenerates the XML. 
- Add a `keydown` handler that blurs the input when `Enter` is pressed so Enter triggers the same commit path, and wire the existing `change` listener to call the deferred commit for these two actions. 
- All changes are in `docs/configurator/app.js` (adjusted event handling and added `commitDeferredTextInput` and Enter-blur behavior).

### Testing

- Ran `node --check docs/configurator/app.js` to validate syntax and it succeeded. 
- Started a local static server with `python -m http.server 4173 -d /workspace/SE-Ship-Core-Framework` and confirmed the configurator page responded with HTTP `200` via `curl -I`. 
- Attempted an automated Playwright screenshot to validate the UI flow, but the browser-container attempt failed with `ERR_EMPTY_RESPONSE` so no screenshot artifact was captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cfe1cd7c88323ab6ee6737026ba92)