### PR TITLE
Add missing core limit fields to configurator output

### DIFF
--- a/docs/configurator/app.js
+++ b/docs/configurator/app.js
@@ -118,6 +118,9 @@ function createDefaultCore() {
     maxBlocks: -1,
     maxMass: -1,
     maxPcu: -1,
+    maxBackupCores: -1,
+    maxPerFaction: -1,
+    minPerFaction: -1,
     maxPerPlayer: -1,
     forceBroadcast: false,
     forceBroadcastRange: 2000,
@@ -335,6 +338,9 @@ function renderShipCores() {
         <label class="inline">MaxBlocks <input data-action="core-maxblocks" data-c="${coreIndex}" class="small" type="number" value="${core.maxBlocks}" /></label>
         <label class="inline">MaxMass <input data-action="core-maxmass" data-c="${coreIndex}" class="small" type="number" value="${core.maxMass}" /></label>
         <label class="inline">MaxPCU <input data-action="core-maxpcu" data-c="${coreIndex}" class="small" type="number" value="${core.maxPcu}" /></label>
+        <label class="inline">MaxBackupCores <input data-action="core-maxbackupcores" data-c="${coreIndex}" class="small" type="number" value="${core.maxBackupCores}" /></label>
+        <label class="inline">MaxPerFaction <input data-action="core-maxpf" data-c="${coreIndex}" class="small" type="number" value="${core.maxPerFaction}" /></label>
+        <label class="inline">MinPerFaction (MinPlayers) <input data-action="core-minpf" data-c="${coreIndex}" class="small" type="number" value="${core.minPerFaction}" /></label>
         <label class="inline">MaxPerPlayer <input data-action="core-maxpp" data-c="${coreIndex}" class="small" type="number" value="${core.maxPerPlayer}" /></label>
       </div>
       <div class="row wrap">
@@ -438,6 +444,9 @@ function parseCoreXml(text, originalFileName = "") {
     maxBlocks: numberOf(coreNode, "MaxBlocks", -1),
     maxMass: numberOf(coreNode, "MaxMass", -1),
     maxPcu: numberOf(coreNode, "MaxPCU", -1),
+    maxBackupCores: numberOf(coreNode, "MaxBackupCores", -1),
+    maxPerFaction: numberOf(coreNode, "MaxPerFaction", -1),
+    minPerFaction: numberOf(coreNode, "MinPlayers", numberOf(coreNode, "MinPerFaction", -1)),
     maxPerPlayer: numberOf(coreNode, "MaxPerPlayer", -1),
     forceBroadcast: boolOf(coreNode, "ForceBroadCast", false),
     forceBroadcastRange: numberOf(coreNode, "ForceBroadCastRange", 2000),
@@ -615,7 +624,7 @@ function generateXml() {
 
   const cores = state.shipCores.map((core) => ({
     file: deriveCoreFilename(core),
-    body: `${header}\n<ShipCore>\n  <SubtypeId>${escapeXml(core.subtypeId)}</SubtypeId>\n  <UniqueName>${escapeXml(core.uniqueName)}</UniqueName>\n  <ForceBroadCast>${core.forceBroadcast}</ForceBroadCast>\n  <ForceBroadCastRange>${core.forceBroadcastRange}</ForceBroadCastRange>\n  <MobilityType>${escapeXml(core.mobilityType)}</MobilityType>\n  <MaxBlocks>${core.maxBlocks}</MaxBlocks>\n  <MaxMass>${core.maxMass}</MaxMass>\n  <MaxPCU>${core.maxPcu}</MaxPCU>\n  <MaxPerPlayer>${core.maxPerPlayer}</MaxPerPlayer>\n  <SpeedBoostEnabled>${core.speedBoostEnabled}</SpeedBoostEnabled>\n  <SpeedLimitType>${escapeXml(core.speedLimitType)}</SpeedLimitType>\n  <EnableActiveDefenseModifiers>${core.enableActiveDefenseModifiers}</EnableActiveDefenseModifiers>\n${writeModifierXml("Modifiers", core.modifiers, DEFAULT_GRID_MODIFIERS)}\n${writeModifierXml("SpeedModifiers", core.speedModifiers, DEFAULT_SPEED_MODIFIERS)}\n${writeModifierXml("PassiveDefenseModifiers", core.passiveDefenseModifiers, DEFAULT_DEFENSE_MODIFIERS)}\n${writeModifierXml("ActiveDefenseModifiers", core.activeDefenseModifiers, DEFAULT_DEFENSE_MODIFIERS)}\n${core.blockLimits
+    body: `${header}\n<ShipCore>\n  <SubtypeId>${escapeXml(core.subtypeId)}</SubtypeId>\n  <UniqueName>${escapeXml(core.uniqueName)}</UniqueName>\n  <ForceBroadCast>${core.forceBroadcast}</ForceBroadCast>\n  <ForceBroadCastRange>${core.forceBroadcastRange}</ForceBroadCastRange>\n  <MobilityType>${escapeXml(core.mobilityType)}</MobilityType>\n  <MaxBlocks>${core.maxBlocks}</MaxBlocks>\n  <MaxMass>${core.maxMass}</MaxMass>\n  <MaxPCU>${core.maxPcu}</MaxPCU>\n  <MaxBackupCores>${core.maxBackupCores}</MaxBackupCores>\n  <MaxPerFaction>${core.maxPerFaction}</MaxPerFaction>\n  <MinPlayers>${core.minPerFaction}</MinPlayers>\n  <MaxPerPlayer>${core.maxPerPlayer}</MaxPerPlayer>\n  <SpeedBoostEnabled>${core.speedBoostEnabled}</SpeedBoostEnabled>\n  <SpeedLimitType>${escapeXml(core.speedLimitType)}</SpeedLimitType>\n  <EnableActiveDefenseModifiers>${core.enableActiveDefenseModifiers}</EnableActiveDefenseModifiers>\n${writeModifierXml("Modifiers", core.modifiers, DEFAULT_GRID_MODIFIERS)}\n${writeModifierXml("SpeedModifiers", core.speedModifiers, DEFAULT_SPEED_MODIFIERS)}\n${writeModifierXml("PassiveDefenseModifiers", core.passiveDefenseModifiers, DEFAULT_DEFENSE_MODIFIERS)}\n${writeModifierXml("ActiveDefenseModifiers", core.activeDefenseModifiers, DEFAULT_DEFENSE_MODIFIERS)}\n${core.blockLimits
       .map((limit) => `  <BlockLimits>\n    <Name>${escapeXml(limit.name)}</Name>\n${limit.blockGroups.map((g) => `    <BlockGroups>${escapeXml(g)}</BlockGroups>`).join("\n")}\n    <MaxCount>${limit.maxCount}</MaxCount>\n    <PunishByNoFlyZone>${limit.punishByNoFlyZone}</PunishByNoFlyZone>\n    <PunishmentType>${escapeXml(limit.punishmentType)}</PunishmentType>\n${(limit.allowedDirections || []).filter(Boolean).map((d) => `    <AllowedDirections>${escapeXml(d)}</AllowedDirections>`).join("\n")}\n  </BlockLimits>`)
       .join("\n")}\n</ShipCore>`
   }));
@@ -693,6 +702,9 @@ document.addEventListener("input", (event) => {
   if (action === "core-maxblocks") state.shipCores[coreIndex].maxBlocks = Number(target.value || -1);
   if (action === "core-maxmass") state.shipCores[coreIndex].maxMass = Number(target.value || -1);
   if (action === "core-maxpcu") state.shipCores[coreIndex].maxPcu = Number(target.value || -1);
+  if (action === "core-maxbackupcores") state.shipCores[coreIndex].maxBackupCores = Number(target.value || -1);
+  if (action === "core-maxpf") state.shipCores[coreIndex].maxPerFaction = Number(target.value || -1);
+  if (action === "core-minpf") state.shipCores[coreIndex].minPerFaction = Number(target.value || -1);
   if (action === "core-maxpp") state.shipCores[coreIndex].maxPerPlayer = Number(target.value || -1);
   if (action === "core-fbr") state.shipCores[coreIndex].forceBroadcastRange = Number(target.value || 0);
 


### PR DESCRIPTION
### Motivation
- Surface and persist the `MaxBackupCores`, `MaxPerFaction` and `MinPlayers` (mapped in the UI as `minPerFaction`) fields in the XML configurator so generated `<ShipCore>` XML matches the C# `ShipCore` model.
- Ensure imported core XML files populate those fields in the editor so round-tripping preserves faction/backup limits.

### Description
- Added new in-memory core properties `maxBackupCores`, `maxPerFaction` and `minPerFaction` in `createDefaultCore` in `docs/configurator/app.js`.
- Added editor inputs for `MaxBackupCores`, `MaxPerFaction` and `MinPerFaction (MinPlayers)` in the core info UI and wired their `data-action` attributes to the state.
- Extended `parseCoreXml` to read `MaxBackupCores`, `MaxPerFaction` and `MinPlayers` (with a compatibility fallback to `MinPerFaction`) from uploaded core XML files.
- Updated `generateXml` to emit `<MaxBackupCores>`, `<MaxPerFaction>` and `<MinPlayers>` tags for each generated `<ShipCore>`, and added input handlers so edits persist to state and the generated XML.

### Testing
- Ran `node --check docs/configurator/app.js` to validate the script syntax, which succeeded.
- Attempted a headless browser screenshot via Playwright to visually validate the UI, but the Chromium launch failed in this environment (SIGSEGV), so UI screenshot validation did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990e8b16a3c8323b0c538f555c7024c)