### PR TITLE
Fix xml configurator search from resetting page scroll

### DIFF
--- a/docs/configurator/app.js
+++ b/docs/configurator/app.js
@@ -426,7 +426,7 @@ function renderShipCores() {
           <div>
             <label>Reusable Block Groups</label>
             <input data-action="limit-group-search" data-c="${coreIndex}" data-l="${limitIndex}" class="small group-search" placeholder="Search block groups" value="${escapeXml(limit.groupSearch || "")}" />
-            <div class="group-checklist">
+            <div class="group-checklist" data-limit-group-list data-c="${coreIndex}" data-l="${limitIndex}">
               ${blockGroupCheckboxes(coreIndex, limitIndex, limit.blockGroups, limit.groupSearch || "")}
             </div>
           </div>
@@ -434,6 +434,16 @@ function renderShipCores() {
       `).join("")}
     </div>
   `;
+}
+
+function renderLimitGroupChecklist(coreIndex, limitIndex) {
+  const limit = state.shipCores[coreIndex]?.blockLimits?.[limitIndex];
+  if (!limit) return;
+
+  const listElement = document.querySelector(`[data-limit-group-list][data-c="${coreIndex}"][data-l="${limitIndex}"]`);
+  if (!listElement) return;
+
+  listElement.innerHTML = blockGroupCheckboxes(coreIndex, limitIndex, limit.blockGroups, limit.groupSearch || "");
 }
 
 function parseGroupsXml(text) {
@@ -934,7 +944,7 @@ document.addEventListener("input", (event) => {
   if (action === "limit-max") state.shipCores[coreIndex].blockLimits[limitIndex].maxCount = Number(target.value || 0);
   if (action === "limit-group-search") {
     state.shipCores[coreIndex].blockLimits[limitIndex].groupSearch = target.value;
-    renderShipCores();
+    renderLimitGroupChecklist(coreIndex, limitIndex);
   }
 
   generateXml();


### PR DESCRIPTION
### Motivation
- Typing into the "Search block groups" field rebuilt the entire ship-core UI via `renderShipCores()`, which caused the page to jump back to the top and disrupted the user's editing flow.
- The goal is to update only the filtered block-group checklist for the specific block limit so input typing doesn't trigger a full re-render or reset scroll position.

### Description
- Added a stable checklist container marker to the reusable block-groups area: `<div class="group-checklist" data-limit-group-list data-c="..." data-l="...">` in `docs/configurator/app.js`.
- Introduced `renderLimitGroupChecklist(coreIndex, limitIndex)` which updates only the checklist HTML for a single limit using `blockGroupCheckboxes(...)`.
- Replaced the previous `renderShipCores()` call in the `limit-group-search` input handler with `renderLimitGroupChecklist(coreIndex, limitIndex)` so typing updates only the targeted checklist.

### Testing
- Ran `node --check docs/configurator/app.js` to verify the modified script syntax and it completed successfully.
- Executed an automated Playwright script against a local server hosting `docs/configurator/index.html` that typed into the `Search block groups` field and captured a screenshot to confirm the checklist updates without jumping the page; the run succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a88dd250d48323852cb10c5cb07db3)