### PR TITLE
Add CrossConnectorPunishment toggle to XML configurator UI

### DIFF
--- a/docs/configurator/app.js
+++ b/docs/configurator/app.js
@@ -236,6 +236,7 @@ function createDefaultLimit() {
   return {
     name: "",
     maxCount: 0,
+    crossConnectorPunishment: false,
     punishByNoFlyZone: false,
     punishmentType: "ShutOff",
     allowedDirections: [],
@@ -467,6 +468,7 @@ function renderShipCores() {
             <button data-action="remove-limit" data-c="${coreIndex}" data-l="${limitIndex}">Delete Limit</button>
           </div>
           <div class="row wrap">
+            <label class="inline">CrossConnectorPunishment <input data-action="limit-cross-connector" data-c="${coreIndex}" data-l="${limitIndex}" type="checkbox" ${limit.crossConnectorPunishment ? "checked" : ""}/></label>
             <label class="inline">PunishByNoFlyZone <input data-action="limit-punish" data-c="${coreIndex}" data-l="${limitIndex}" type="checkbox" ${limit.punishByNoFlyZone ? "checked" : ""}/></label>
             <label class="inline">Punishment Type
               <select data-action="limit-type" data-c="${coreIndex}" data-l="${limitIndex}" class="small">
@@ -547,6 +549,7 @@ function parseCoreXml(text, originalFileName = "") {
     blockLimits: Array.from(coreNode.querySelectorAll(":scope > BlockLimits")).map((limitNode) => ({
       name: textOf(limitNode, "Name"),
       maxCount: numberOf(limitNode, "MaxCount", 0),
+      crossConnectorPunishment: boolOf(limitNode, "CrossConnectorPunishment", false),
       punishByNoFlyZone: boolOf(limitNode, "PunishByNoFlyZone", boolOf(limitNode, "TurnedOffByNoFlyZone", false)),
       punishmentType: textOf(limitNode, "PunishmentType") || "ShutOff",
       allowedDirections: Array.from(limitNode.querySelectorAll(":scope > AllowedDirections")).map((node) => node.textContent.trim()).filter(Boolean),
@@ -628,6 +631,7 @@ function parseLegacyLimit(limitNode) {
   return {
     name: textOf(limitNode, "Name"),
     maxCount: numberOf(limitNode, "MaxCount", 0),
+    crossConnectorPunishment: boolOf(limitNode, "CrossConnectorPunishment", false),
     punishByNoFlyZone: boolOf(limitNode, "TurnedOffByNoFlyZone", boolOf(limitNode, "PunishByNoFlyZone", false)),
     punishmentType: textOf(limitNode, "PunishmentType") || "ShutOff",
     allowedDirections: [],
@@ -890,7 +894,7 @@ function generateXml() {
 
   const noCore = state.noCoreCore
     ? `${header}\n<ShipCore>\n  <SubtypeId>${escapeXml(state.noCoreCore.subtypeId)}</SubtypeId>\n  <UniqueName>${escapeXml(state.noCoreCore.uniqueName)}</UniqueName>\n  <ForceBroadCast>${state.noCoreCore.forceBroadcast}</ForceBroadCast>\n  <ForceBroadCastRange>${state.noCoreCore.forceBroadcastRange}</ForceBroadCastRange>\n  <MobilityType>${escapeXml(state.noCoreCore.mobilityType)}</MobilityType>\n  <MaxBlocks>${state.noCoreCore.maxBlocks}</MaxBlocks>\n  <MaxMass>${state.noCoreCore.maxMass}</MaxMass>\n  <MaxPCU>${state.noCoreCore.maxPcu}</MaxPCU>\n  <MaxBackupCores>${state.noCoreCore.maxBackupCores}</MaxBackupCores>\n  <MaxPerPlayer>${state.noCoreCore.maxPerPlayer}</MaxPerPlayer>\n  <MinPlayers>${state.noCoreCore.minPerFaction}</MinPlayers>\n  <MaxPerFaction>${state.noCoreCore.maxPerFaction}</MaxPerFaction>\n  <SpeedBoostEnabled>${state.noCoreCore.speedBoostEnabled}</SpeedBoostEnabled>\n  <SpeedLimitType>${escapeXml(state.noCoreCore.speedLimitType)}</SpeedLimitType>\n  <EnableActiveDefenseModifiers>${state.noCoreCore.enableActiveDefenseModifiers}</EnableActiveDefenseModifiers>\n${writeModifierXml("Modifiers", state.noCoreCore.modifiers, DEFAULT_GRID_MODIFIERS)}\n${writeModifierXml("SpeedModifiers", state.noCoreCore.speedModifiers, DEFAULT_SPEED_MODIFIERS)}\n${writeModifierXml("PassiveDefenseModifiers", state.noCoreCore.passiveDefenseModifiers, DEFAULT_DEFENSE_MODIFIERS)}\n${writeModifierXml("ActiveDefenseModifiers", state.noCoreCore.activeDefenseModifiers, DEFAULT_DEFENSE_MODIFIERS)}\n${state.noCoreCore.blockLimits
-      .map((limit) => `  <BlockLimits>\n    <Name>${escapeXml(limit.name)}</Name>\n${limit.blockGroups.map((g) => `    <BlockGroups>${escapeXml(g)}</BlockGroups>`).join("\n")}\n    <MaxCount>${limit.maxCount}</MaxCount>\n    <PunishByNoFlyZone>${limit.punishByNoFlyZone}</PunishByNoFlyZone>\n    <PunishmentType>${escapeXml(limit.punishmentType)}</PunishmentType>\n${(limit.allowedDirections || []).filter(Boolean).map((d) => `    <AllowedDirections>${escapeXml(d)}</AllowedDirections>`).join("\n")}\n  </BlockLimits>`)
+      .map((limit) => `  <BlockLimits>\n    <Name>${escapeXml(limit.name)}</Name>\n${limit.blockGroups.map((g) => `    <BlockGroups>${escapeXml(g)}</BlockGroups>`).join("\n")}\n    <MaxCount>${limit.maxCount}</MaxCount>\n    <CrossConnectorPunishment>${limit.crossConnectorPunishment}</CrossConnectorPunishment>\n    <PunishByNoFlyZone>${limit.punishByNoFlyZone}</PunishByNoFlyZone>\n    <PunishmentType>${escapeXml(limit.punishmentType)}</PunishmentType>\n${(limit.allowedDirections || []).filter(Boolean).map((d) => `    <AllowedDirections>${escapeXml(d)}</AllowedDirections>`).join("\n")}\n  </BlockLimits>`)
       .join("\n")}\n</ShipCore>`
     : `${header}\n<ShipCore />`;
 
@@ -908,7 +912,7 @@ function generateXml() {
   const cores = state.shipCores.map((core) => ({
     file: deriveCoreFilename(core),
     body: `${header}\n<ShipCore>\n  <SubtypeId>${escapeXml(core.subtypeId)}</SubtypeId>\n  <UniqueName>${escapeXml(core.uniqueName)}</UniqueName>\n  <ForceBroadCast>${core.forceBroadcast}</ForceBroadCast>\n  <ForceBroadCastRange>${core.forceBroadcastRange}</ForceBroadCastRange>\n  <MobilityType>${escapeXml(core.mobilityType)}</MobilityType>\n  <MaxBlocks>${core.maxBlocks}</MaxBlocks>\n  <MaxMass>${core.maxMass}</MaxMass>\n  <MaxPCU>${core.maxPcu}</MaxPCU>\n  <MaxBackupCores>${core.maxBackupCores}</MaxBackupCores>\n  <MaxPerPlayer>${core.maxPerPlayer}</MaxPerPlayer>\n  <MinPlayers>${core.minPerFaction}</MinPlayers>\n  <MaxPerFaction>${core.maxPerFaction}</MaxPerFaction>\n  <SpeedBoostEnabled>${core.speedBoostEnabled}</SpeedBoostEnabled>\n  <SpeedLimitType>${escapeXml(core.speedLimitType)}</SpeedLimitType>\n  <EnableActiveDefenseModifiers>${core.enableActiveDefenseModifiers}</EnableActiveDefenseModifiers>\n${writeModifierXml("Modifiers", core.modifiers, DEFAULT_GRID_MODIFIERS)}\n${writeModifierXml("SpeedModifiers", core.speedModifiers, DEFAULT_SPEED_MODIFIERS)}\n${writeModifierXml("PassiveDefenseModifiers", core.passiveDefenseModifiers, DEFAULT_DEFENSE_MODIFIERS)}\n${writeModifierXml("ActiveDefenseModifiers", core.activeDefenseModifiers, DEFAULT_DEFENSE_MODIFIERS)}\n${core.blockLimits
-      .map((limit) => `  <BlockLimits>\n    <Name>${escapeXml(limit.name)}</Name>\n${limit.blockGroups.map((g) => `    <BlockGroups>${escapeXml(g)}</BlockGroups>`).join("\n")}\n    <MaxCount>${limit.maxCount}</MaxCount>\n    <PunishByNoFlyZone>${limit.punishByNoFlyZone}</PunishByNoFlyZone>\n    <PunishmentType>${escapeXml(limit.punishmentType)}</PunishmentType>\n${(limit.allowedDirections || []).filter(Boolean).map((d) => `    <AllowedDirections>${escapeXml(d)}</AllowedDirections>`).join("\n")}\n  </BlockLimits>`)
+      .map((limit) => `  <BlockLimits>\n    <Name>${escapeXml(limit.name)}</Name>\n${limit.blockGroups.map((g) => `    <BlockGroups>${escapeXml(g)}</BlockGroups>`).join("\n")}\n    <MaxCount>${limit.maxCount}</MaxCount>\n    <CrossConnectorPunishment>${limit.crossConnectorPunishment}</CrossConnectorPunishment>\n    <PunishByNoFlyZone>${limit.punishByNoFlyZone}</PunishByNoFlyZone>\n    <PunishmentType>${escapeXml(limit.punishmentType)}</PunishmentType>\n${(limit.allowedDirections || []).filter(Boolean).map((d) => `    <AllowedDirections>${escapeXml(d)}</AllowedDirections>`).join("\n")}\n  </BlockLimits>`)
       .join("\n")}\n</ShipCore>`
   }));
 
@@ -1105,6 +1109,10 @@ document.addEventListener("change", (event) => {
   if (action === "core-speed-limit-type" && selectElement) state.shipCores[coreIndex].speedLimitType = selectElement.value;
   if (action === "limit-punish" && inputElement) {
     state.shipCores[coreIndex].blockLimits[limitIndex].punishByNoFlyZone = inputElement.checked;
+    renderShipCores();
+  }
+  if (action === "limit-cross-connector" && inputElement) {
+    state.shipCores[coreIndex].blockLimits[limitIndex].crossConnectorPunishment = inputElement.checked;
     renderShipCores();
   }
   if (action === "limit-type" && selectElement) {


### PR DESCRIPTION
### Motivation
- The modconfig gained a new `<CrossConnectorPunishment>` boolean for block limits and the XML configurator needs a UI control to edit that value.
- The editor must parse and emit the new element so round-tripping (import → edit → export) preserves the flag.
- No extra skills were required for this change.

### Description
- Added `crossConnectorPunishment` to the limit model and `createDefaultLimit()` so new/duplicated limits include the flag (`docs/configurator/app.js`).
- Added a checkbox UI control labeled `CrossConnectorPunishment` on each Block Limit card and wired it to the view with `data-action="limit-cross-connector"`.
- Updated XML import paths (standard core and legacy parsing) to read `<CrossConnectorPunishment>` into state, and updated XML generation for both no-core and per-core outputs to write `<CrossConnectorPunishment>`.
- Wired change handling so toggling the new checkbox updates `state.shipCores[...].blockLimits[...]` and triggers re-rendering and XML regeneration.

### Testing
- Ran `node --check docs/configurator/app.js` with no errors, which succeeded.
- Served the configurator via `python3 -m http.server 8000` and manually verified the new checkbox is rendered in the UI, which succeeded.
- Captured a Playwright screenshot of `http://127.0.0.1:8000/configurator/` to validate the UI visually, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8a7b662a4832392b0d71d0b106d63)