### PR TITLE
Make block-limit panels collapsible with per-core expanded state and styling updates

### DIFF
--- a/docs/configurator/app.js
+++ b/docs/configurator/app.js
@@ -4,7 +4,8 @@ const state = {
   shipCores: [],
   selectedGroupIndex: 0,
   selectedCoreIndex: 0,
-  noCoreCore: null
+  noCoreCore: null,
+  expandedLimitPanelsByCore: {}
 };
 
 const DEFAULT_GRID_MODIFIERS = {
@@ -108,6 +109,40 @@ function parseModifierNode(node, defaults) {
   });
 
   return parsed;
+}
+
+
+
+function normalizeExpandedLimitPanelsForCore(coreIndex) {
+  const core = state.shipCores[coreIndex];
+  if (!core) {
+    delete state.expandedLimitPanelsByCore[coreIndex];
+    return [];
+  }
+
+  const maxLimitIndex = core.blockLimits.length - 1;
+  const expanded = Array.isArray(state.expandedLimitPanelsByCore[coreIndex])
+    ? state.expandedLimitPanelsByCore[coreIndex]
+    : [];
+
+  const normalized = expanded
+    .filter((index) => Number.isInteger(index) && index >= 0 && index <= maxLimitIndex)
+    .filter((index, position, arr) => arr.indexOf(index) === position)
+    .slice(-2);
+
+  state.expandedLimitPanelsByCore[coreIndex] = normalized;
+  return normalized;
+}
+
+
+function shiftExpandedLimitPanelsAfterCoreRemoval(removedCoreIndex) {
+  const shifted = {};
+  Object.entries(state.expandedLimitPanelsByCore).forEach(([key, value]) => {
+    const index = Number(key);
+    if (!Number.isInteger(index) || index === removedCoreIndex) return;
+    shifted[index > removedCoreIndex ? index - 1 : index] = value;
+  });
+  state.expandedLimitPanelsByCore = shifted;
 }
 
 function createDefaultCore() {
@@ -251,6 +286,7 @@ function resetEditor(seed = true) {
   state.selectedGroupIndex = 0;
   state.selectedCoreIndex = 0;
   state.noCoreCore = null;
+  state.expandedLimitPanelsByCore = {};
 
   if (seed) {
     addBlockGroup({ name: "Weaponry", blockTypes: [{ typeId: "SmallGatlingGun", subtypeId: "", countWeight: 1 }] });
@@ -338,10 +374,13 @@ function blockGroupCheckboxes(coreIndex, limitIndex, selected = [], searchText =
   return state.blockGroups
     .filter((group) => group.name.trim())
     .filter((group) => !normalizedSearch || group.name.toLowerCase().includes(normalizedSearch))
-    .map((group) => `<label class="group-checklist-item">
-      <input data-action="limit-group-toggle" data-c="${coreIndex}" data-l="${limitIndex}" data-group-name="${escapeXml(group.name)}" type="checkbox" ${selected.includes(group.name) ? "checked" : ""} />
+    .map((group) => {
+      const isSelected = selected.includes(group.name);
+      return `<label class="group-checklist-item ${isSelected ? "selected" : ""}">
+      <input data-action="limit-group-toggle" data-c="${coreIndex}" data-l="${limitIndex}" data-group-name="${escapeXml(group.name)}" type="checkbox" ${isSelected ? "checked" : ""} />
       <span>${escapeXml(group.name)}</span>
-    </label>`)
+    </label>`;
+    })
     .join("");
 }
 
@@ -394,6 +433,7 @@ function renderShipCores() {
 
   const coreIndex = state.selectedCoreIndex;
   const core = state.shipCores[coreIndex];
+  const expandedLimitPanels = normalizeExpandedLimitPanelsForCore(coreIndex);
 
   ids("shipCores").innerHTML = `
     <div class="card">
@@ -460,7 +500,9 @@ function renderShipCores() {
       </div>
 
       ${core.blockLimits.map((limit, limitIndex) => `
-        <div class="card">
+        <details class="card block-limit-panel" data-action="limit-toggle" data-c="${coreIndex}" data-l="${limitIndex}" ${expandedLimitPanels.includes(limitIndex) ? "open" : ""}>
+          <summary class="block-limit-summary">${escapeXml(limit.name?.trim() || `Block Limit ${limitIndex + 1}`)}</summary>
+          <div class="block-limit-content">
           <div class="row wrap">
             <input data-action="limit-name" data-c="${coreIndex}" data-l="${limitIndex}" class="small" placeholder="Limit Name" value="${escapeXml(limit.name)}" />
             <label class="inline">MaxCount <input data-action="limit-max" data-c="${coreIndex}" data-l="${limitIndex}" class="small" type="number" step="0.1" value="${limit.maxCount}" /></label>
@@ -489,7 +531,8 @@ function renderShipCores() {
               ${blockGroupCheckboxes(coreIndex, limitIndex, limit.blockGroups, limit.groupSearch || "")}
             </div>
           </div>
-        </div>
+          </div>
+        </details>
       `).join("")}
     </div>
   `;
@@ -970,6 +1013,7 @@ document.addEventListener("click", (event) => {
   }
   if (action === "remove-core") {
     state.shipCores.splice(coreIndex, 1);
+    shiftExpandedLimitPanelsAfterCoreRemoval(coreIndex);
     if (state.selectedCoreIndex >= state.shipCores.length) state.selectedCoreIndex = state.shipCores.length - 1;
     didMutate = true;
   }
@@ -978,23 +1022,36 @@ document.addEventListener("click", (event) => {
     if (sourceCore) {
       const duplicatedCore = cloneShipCore(sourceCore);
       state.shipCores.splice(coreIndex + 1, 0, duplicatedCore);
+
+      const shifted = {};
+      Object.entries(state.expandedLimitPanelsByCore).forEach(([key, value]) => {
+        const index = Number(key);
+        if (!Number.isInteger(index)) return;
+        shifted[index > coreIndex ? index + 1 : index] = value;
+      });
+      state.expandedLimitPanelsByCore = shifted;
+      state.expandedLimitPanelsByCore[coreIndex + 1] = [];
+
       state.selectedCoreIndex = coreIndex + 1;
       didMutate = true;
     }
   }
   if (action === "add-limit") {
     state.shipCores[coreIndex].blockLimits.push(createDefaultLimit());
+    normalizeExpandedLimitPanelsForCore(coreIndex);
     didMutate = true;
   }
   if (action === "duplicate-limit") {
     const sourceLimit = state.shipCores[coreIndex]?.blockLimits?.[limitIndex];
     if (sourceLimit) {
       state.shipCores[coreIndex].blockLimits.splice(limitIndex + 1, 0, cloneLimit(sourceLimit));
+      normalizeExpandedLimitPanelsForCore(coreIndex);
       didMutate = true;
     }
   }
   if (action === "remove-limit") {
     state.shipCores[coreIndex].blockLimits.splice(limitIndex, 1);
+    normalizeExpandedLimitPanelsForCore(coreIndex);
     didMutate = true;
   }
 
@@ -1145,6 +1202,30 @@ document.addEventListener("change", (event) => {
   generateXml();
 });
 
+document.addEventListener("toggle", (event) => {
+  const target = event.target;
+  if (!(target instanceof HTMLDetailsElement)) return;
+  if (target.dataset.action !== "limit-toggle") return;
+
+  const coreIndex = Number(target.dataset.c);
+  const limitIndex = Number(target.dataset.l);
+  if (!Number.isInteger(coreIndex) || !Number.isInteger(limitIndex)) return;
+
+  const expanded = normalizeExpandedLimitPanelsForCore(coreIndex);
+  if (target.open) {
+    const nextExpanded = [...expanded.filter((index) => index !== limitIndex), limitIndex];
+    while (nextExpanded.length > 2) {
+      const removedLimitIndex = nextExpanded.shift();
+      const detailsToClose = document.querySelector(`details[data-action="limit-toggle"][data-c="${coreIndex}"][data-l="${removedLimitIndex}"]`);
+      if (detailsToClose instanceof HTMLDetailsElement) detailsToClose.open = false;
+    }
+    state.expandedLimitPanelsByCore[coreIndex] = nextExpanded;
+    return;
+  }
+
+  state.expandedLimitPanelsByCore[coreIndex] = expanded.filter((index) => index !== limitIndex);
+}, true);
+
 ids("selectedGroup").addEventListener("change", (event) => {
   state.selectedGroupIndex = Number(event.target.value);
   renderBlockGroups();
@@ -1193,6 +1274,7 @@ ids("loadLegacyModConfig").addEventListener("click", async () => {
   state.blockGroups = migrated.blockGroups;
   state.selectedGroupIndex = 0;
   state.selectedCoreIndex = 0;
+  state.expandedLimitPanelsByCore = {};
 
   renderBlockGroups();
   renderShipCores();
@@ -1237,6 +1319,7 @@ ids("loadUploadedXml").addEventListener("click", async () => {
   }
 
   state.selectedCoreIndex = 0;
+  state.expandedLimitPanelsByCore = {};
 
   if (state.noCoreCore) status.push(`Loaded no-core from ${state.noCoreCore.originalFileName || "legacy import"}.`);
   if (state.blockGroups.length === 0) status.push("No block groups loaded (you can still create them manually).");

--- a/docs/configurator/styles.css
+++ b/docs/configurator/styles.css
@@ -79,6 +79,20 @@ button:hover { background: #0d9488; }
   padding: 0.75rem;
   margin: 0.65rem 0;
 }
+
+.block-limit-panel {
+  padding: 0;
+}
+
+.block-limit-summary {
+  cursor: pointer;
+  padding: 0.75rem;
+  font-weight: 600;
+}
+
+.block-limit-content {
+  padding: 0 0.75rem 0.75rem;
+}
 .card h4 { margin: 0.25rem 0 0.5rem; }
 .small { width: 220px; }
 .inline { display: inline-flex; gap: 0.5rem; align-items: center; margin-right: 1rem; }
@@ -127,7 +141,13 @@ button:hover { background: #0d9488; }
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.2rem 0;
+  padding: 0.2rem 0.4rem;
+  border-radius: 6px;
+}
+
+.group-checklist-item.selected {
+  background: rgba(34, 197, 94, 0.2);
+  color: #86efac;
 }
 .group-checklist-item input {
   width: auto;


### PR DESCRIPTION
### Motivation
- Improve the block limits editor UX by making each limit collapsible so editors with many limits are easier to navigate.
- Limit the number of simultaneously expanded limit panels per core to avoid overwhelming the UI and to preserve user context when cores or limits are added/removed/duplicated.
- Provide clearer visual feedback for selected block groups in the reusable checklist.

### Description
- Added a per-core expanded state `expandedLimitPanelsByCore` to `state` and initialization in `resetEditor` and import flows to track opened limit panels by core index.
- Implemented `normalizeExpandedLimitPanelsForCore` and `shiftExpandedLimitPanelsAfterCoreRemoval` helpers and updated core/limit add/duplicate/remove flows to maintain and normalize expanded panel indexes across mutations.
- Replaced block-limit `div.card` blocks with semantic `<details class="card block-limit-panel">` and `<summary>` elements in `renderShipCores`, and added a delegated `toggle` listener to enforce a maximum of two open panels per core and update state accordingly.
- Updated `blockGroupCheckboxes` to render a selectable checklist item with a `selected` class and refactored markup to include a `span` for the label, plus added CSS rules (`.block-limit-panel`, `.block-limit-summary`, `.block-limit-content`, `.group-checklist-item.selected`) to support the new UI and styling.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8ae6258f48323b5feb6c2cc6e32c8)