### PR TITLE
Fix legacy no-core mapping to avoid full-core duplication

### DIFF
--- a/docs/configurator/app.js
+++ b/docs/configurator/app.js
@@ -800,6 +800,39 @@ function parseLegacyGridClass(gridClassNode, fallbackSubtype) {
   return mapped;
 }
 
+function findLegacyDefaultGridClassNode(root) {
+  const selectors = [
+    ":scope > DefaultGridClass",
+    ":scope > GridClasses > DefaultGridClass",
+    ":scope > ShipClasses > DefaultGridClass",
+    ":scope > ShipClasses > ShipClass > DefaultGridClass"
+  ];
+
+  for (const selector of selectors) {
+    const found = root.querySelector(selector);
+    if (found) return found;
+  }
+
+  return null;
+}
+
+function findLegacyShipGridClassNodes(root) {
+  const selectors = [
+    ":scope > GridClasses > GridClass",
+    ":scope > ShipClasses > GridClass",
+    ":scope > ShipClasses > ShipClass > GridClass"
+  ];
+
+  const nodes = [];
+  selectors.forEach((selector) => {
+    root.querySelectorAll(selector).forEach((node) => {
+      if (!nodes.includes(node)) nodes.push(node);
+    });
+  });
+
+  return nodes;
+}
+
 function applyLegacyGroupDedup(noCoreCore, shipCores, mergeMode = "strict") {
   const allCores = [noCoreCore, ...shipCores].filter(Boolean);
   const signatureToGroupName = new Map();
@@ -866,8 +899,8 @@ function migrateLegacyModConfig(text, sourceName = "uploaded xml", mergeMode = "
   const root = doc.querySelector("ModConfig");
   if (!root) return { error: `No <ModConfig> root found in ${sourceName}.` };
 
-  const defaultGridClassNode = root.querySelector(":scope > DefaultGridClass");
-  const gridClassNodes = Array.from(root.querySelectorAll(":scope > GridClasses > GridClass"));
+  const defaultGridClassNode = findLegacyDefaultGridClassNode(root);
+  const gridClassNodes = findLegacyShipGridClassNodes(root);
 
   if (!defaultGridClassNode && gridClassNodes.length === 0) {
     return { error: `No <DefaultGridClass> or <GridClass> entries found in ${sourceName}.` };
@@ -880,13 +913,14 @@ function migrateLegacyModConfig(text, sourceName = "uploaded xml", mergeMode = "
     noCoreCore.originalFileName = "ShipCoreConfig_No_Core.xml";
   }
 
-  const shipCores = gridClassNodes.map((node, index) => parseLegacyGridClass(node, `GridClass_${index + 1}`));
+  const shipGridClassNodes = gridClassNodes.filter((node) => node !== defaultGridClassNode);
+  const shipCores = shipGridClassNodes.map((node, index) => parseLegacyGridClass(node, `GridClass_${index + 1}`));
   const blockGroups = applyLegacyGroupDedup(noCoreCore, shipCores, mergeMode);
 
   const status = [
     `Migrated legacy file ${sourceName}.`,
     noCoreCore ? "Mapped DefaultGridClass into ShipCoreConfig_No_Core.xml." : "No DefaultGridClass found.",
-    `Mapped ${shipCores.length} GridClass entries to ShipCore cores.`,
+    `Mapped ${shipCores.length} GridClass entries to ShipCore cores (excluding the default no-core class).`,
     `Generated ${blockGroups.length} reusable block groups via cross-core limit dedupe (${mergeMode}).`
   ];
 


### PR DESCRIPTION
### Motivation

- Legacy ModConfig XML files used different layouts for the default grid class and ship/grid entries, and the previous migrator path only matched one strict location which caused the no-core `DefaultGridClass` to be imported again as a normal core, making the "no core" behave like a full core.
- The configurator needs to reliably map older `DefaultGridClass` entries into the separate `ShipCoreConfig_No_Core.xml` and collect all legacy `GridClass` entries regardless of wrapper structure.

### Description

- Added `findLegacyDefaultGridClassNode` which searches multiple legacy selectors (`DefaultGridClass` under several possible parent nodes) to locate the default/no-core node in varied schemas.
- Added `findLegacyShipGridClassNodes` which collects `GridClass` nodes from multiple legacy layouts and deduplicates nodes found via different selectors.
- Filtered out the detected default node from the ship/core list so the no-core default is not imported again as a normal core and updated the migration status message to clarify the counted cores.

### Testing

- Ran `node --check docs/configurator/app.js` which succeeded without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa0748a81c8323bbb00c8ef040b31b)