### PR TITLE
Fix configurator zip/XML downloads missing in-focus edits

### DIFF
--- a/docs/configurator/app.js
+++ b/docs/configurator/app.js
@@ -1270,6 +1270,16 @@ function commitDeferredTextInput(target) {
   }
 }
 
+function flushActiveDeferredInput() {
+  const activeElement = document.activeElement;
+  if (!(activeElement instanceof HTMLInputElement)) return;
+
+  const action = activeElement.dataset.action;
+  if (action !== "group-name" && action !== "core-subtype") return;
+
+  commitDeferredTextInput(activeElement);
+}
+
 document.addEventListener("keydown", (event) => {
   if (event.key !== "Enter") return;
 
@@ -1381,7 +1391,10 @@ ids("selectedCore").addEventListener("change", (event) => {
 
 ids("addGroup").addEventListener("click", () => addBlockGroup({ name: "", blockTypes: [] }));
 ids("addCore").addEventListener("click", () => addShipCore());
-ids("generateXml").addEventListener("click", () => generateXml());
+ids("generateXml").addEventListener("click", () => {
+  flushActiveDeferredInput();
+  generateXml();
+});
 ids("resetEditor").addEventListener("click", () => {
   resetEditor(true);
   setImportStatus(["Editor reset to starter seed data."]);
@@ -1393,21 +1406,25 @@ ids("resetDraftStorage").addEventListener("click", () => {
 });
 
 ids("downloadNoCore").addEventListener("click", () => {
+  flushActiveDeferredInput();
   const xml = generateXml({ persistDraft: false });
   download("ShipCoreConfig_No_Core.xml", xml.noCore);
   clearDraftFromStorage();
 });
 ids("downloadGroups").addEventListener("click", () => {
+  flushActiveDeferredInput();
   const xml = generateXml({ persistDraft: false });
   download("ShipCoreConfig_Groups.xml", xml.groups);
   clearDraftFromStorage();
 });
 ids("downloadManifest").addEventListener("click", () => {
+  flushActiveDeferredInput();
   const xml = generateXml({ persistDraft: false });
   download("ShipCoreConfig_Manifest.xml", xml.manifest);
   clearDraftFromStorage();
 });
 ids("downloadCores").addEventListener("click", () => {
+  flushActiveDeferredInput();
   const xml = generateXml({ persistDraft: false });
   const zip = createZip(xml.cores.map((core) => ({ name: core.file, content: core.body })));
   downloadBlob("ShipCore_XMLs.zip", zip);


### PR DESCRIPTION
### Motivation
- Clicking Generate/Download while a deferred text input (`group-name` or `core-subtype`) is still focused produced stale XML/zip contents because those fields were only committed on `change`/blur. 

### Description
- Add `flushActiveDeferredInput()` which inspects `document.activeElement` and calls `commitDeferredTextInput()` for `group-name` and `core-subtype` inputs. 
- Call `flushActiveDeferredInput()` from the `Generate XML` handler and all download handlers (`downloadNoCore`, `downloadGroups`, `downloadManifest`, `downloadCores`) so exports include in-focus edits. 
- Preserve existing deferred-commit behavior on `change`/blur while ensuring button-driven flows also flush pending edits. 

### Testing
- Run `node --check docs/configurator/app.js` which completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa7d1608e483239b57fb43d5debd11)