### PR TITLE
Always show Duplicate for No-Core, disable Delete, and inline no-core checks

### DIFF
--- a/docs/configurator/app.js
+++ b/docs/configurator/app.js
@@ -248,10 +248,6 @@ function getEditorCoreByIndex(editorCoreIndex) {
   return state.shipCores[editorCoreIndex - 1] ?? null;
 }
 
-function isNoCoreEditorIndex(editorCoreIndex) {
-  return editorCoreIndex === 0;
-}
-
 function addBlockGroup(group = { name: "", blockTypes: [] }) {
   state.blockGroups.push(group);
   state.selectedGroupIndex = state.blockGroups.length - 1;
@@ -521,7 +517,7 @@ function renderShipCores() {
     ids("shipCores").innerHTML = `<p class="muted">No core configuration is selected.</p>`;
     return;
   }
-  const isNoCore = isNoCoreEditorIndex(coreIndex);
+  const isNoCore = coreIndex === 0;
   const expandedLimitPanels = normalizeExpandedLimitPanelsForCore(coreIndex);
 
   ids("shipCores").innerHTML = `
@@ -534,8 +530,8 @@ function renderShipCores() {
             ${["Static", "Mobile", "Both"].map((value) => `<option ${core.mobilityType === value ? "selected" : ""}>${value}</option>`).join("")}
           </select>
         </label>
-        ${isNoCore ? "" : `<button data-action="duplicate-core" data-c="${coreIndex}">Duplicate Core</button>`}
-        ${isNoCore ? "" : `<button data-action="remove-core" data-c="${coreIndex}">Delete Core</button>`}
+        <button data-action="duplicate-core" data-c="${coreIndex}">Duplicate Core</button>
+        <button data-action="remove-core" data-c="${coreIndex}" ${isNoCore ? "disabled" : ""}>Delete Core</button>
       </div>
       <div class="row wrap">
         <label class="inline">MaxBlocks <input data-action="core-maxblocks" data-c="${coreIndex}" class="small" type="number" value="${core.maxBlocks}" /></label>
@@ -1137,13 +1133,12 @@ document.addEventListener("click", (event) => {
     }
   }
   if (action === "remove-core") {
-    if (!isNoCoreEditorIndex(coreIndex)) {
-      const shipCoreIndex = coreIndex - 1;
-      state.shipCores.splice(shipCoreIndex, 1);
-      shiftExpandedLimitPanelsAfterCoreRemoval(coreIndex);
-      const maxEditorIndex = state.shipCores.length + (state.noCoreCore ? 1 : 0) - 1;
-      if (state.selectedCoreIndex > maxEditorIndex) state.selectedCoreIndex = maxEditorIndex;
-    }
+    if (coreIndex === 0) return;
+
+    state.shipCores.splice(coreIndex - 1, 1);
+    shiftExpandedLimitPanelsAfterCoreRemoval(coreIndex);
+    const maxEditorIndex = state.shipCores.length + (state.noCoreCore ? 1 : 0) - 1;
+    if (state.selectedCoreIndex > maxEditorIndex) state.selectedCoreIndex = maxEditorIndex;
     didMutate = true;
   }
   if (action === "duplicate-core") {


### PR DESCRIPTION
### Motivation
- Simplify core-index checks and UI behavior around the special "No Core" editor entry by inlining the `editorCoreIndex === 0` check and removing a trivial helper.
- Improve editor UX by still allowing the Duplicate action to be visible for the "No Core" entry while preventing deletion via a disabled Delete button.
- Keep the limit-panel index shifting logic consistent when cores are removed or duplicated.

### Description
- Removed the `isNoCoreEditorIndex` helper and replaced its usages with direct `coreIndex === 0` checks.
- Render the Duplicate button for all cores (including the No Core entry) and render the Delete button with `disabled` when `coreIndex === 0` instead of hiding it.
- Simplified the `remove-core` click handler to early-return for `coreIndex === 0` and then remove the corresponding `shipCores` entry and update expanded limit panels and selection bounds.
- Preserved existing behaviors for duplicating cores and shifting `expandedLimitPanelsByCore` when inserting a duplicated core.

### Testing
- Ran `npm run lint` against the modified files and the linter passed without new errors.
- Ran `npm test` (project unit tests) and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa864afcf88323ac3eebf72d058201)