### PR TITLE
Place generated core XML zip files in Cores/ subfolder

### DIFF
--- a/docs/configurator/app.js
+++ b/docs/configurator/app.js
@@ -1405,7 +1405,7 @@ ids("downloadManifest").addEventListener("click", () => {
 });
 ids("downloadCores").addEventListener("click", () => {
   const xml = generateXml({ persistDraft: false });
-  const zip = createZip(xml.cores.map((core) => ({ name: core.file, content: core.body })));
+  const zip = createZip(xml.cores.map((core) => ({ name: `Cores/${core.file}`, content: core.body })));
   downloadBlob("ShipCore_XMLs.zip", zip);
   clearDraftFromStorage();
 });


### PR DESCRIPTION
### Motivation
- Ensure the ZIP produced by the configurator places each generated ShipCore XML into a `Cores/` subfolder so packaged files align with the manifest path conventions and avoid placing core XMLs at the ZIP root.

### Description
- Update `docs/configurator/app.js` so the `downloadCores` handler calls `createZip` with entries named ``Cores/${core.file}`` instead of the previous top-level `core.file`.

### Testing
- Verified the changed handler in the file output with `nl -ba docs/configurator/app.js | sed -n '1402,1412p'` showing the `Cores/${core.file}` mapping. 
- Checked repository status and pattern presence using `git status --short` and `rg -n "downloadCores|Cores/\$\{core\.file\}" docs/configurator/app.js`. 
- Confirmed the change was committed via `git show --stat --oneline HEAD`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab17e7a8ec83238f352e232261adcb)