### PR TITLE
Add “Download all files” ZIP action to XML configurator

### DIFF
--- a/docs/configurator/app.js
+++ b/docs/configurator/app.js
@@ -1403,6 +1403,17 @@ ids("downloadManifest").addEventListener("click", () => {
   download("ShipCoreConfig_Manifest.xml", xml.manifest);
   clearDraftFromStorage();
 });
+ids("downloadAllFiles").addEventListener("click", () => {
+  const xml = generateXml({ persistDraft: false });
+  const zip = createZip([
+    { name: "ShipCoreConfig_No_Core.xml", content: xml.noCore },
+    { name: "ShipCoreConfig_Groups.xml", content: xml.groups },
+    { name: "ShipCoreConfig_Manifest.xml", content: xml.manifest },
+    ...xml.cores.map((core) => ({ name: `Cores/${core.file}`, content: core.body }))
+  ]);
+  downloadBlob("ShipCore_All_Files.zip", zip);
+  clearDraftFromStorage();
+});
 ids("downloadCores").addEventListener("click", () => {
   const xml = generateXml({ persistDraft: false });
   const zip = createZip(xml.cores.map((core) => ({ name: `Cores/${core.file}`, content: core.body })));

--- a/docs/configurator/index.html
+++ b/docs/configurator/index.html
@@ -84,6 +84,7 @@
       <p class="muted">Generated XML previews update automatically as you edit.</p>
       <div class="row wrap">
         <button hidden="hidden" id="generateXml">Generate</button>
+        <button id="downloadAllFiles" class="button-green">Download all files (.zip)</button>
         <button id="downloadNoCore">Download ShipCoreConfig_No_Core.xml</button>
         <button id="downloadGroups">Download ShipCoreConfig_Groups.xml</button>
         <button id="downloadManifest">Download ShipCoreConfig_Manifest.xml</button>

--- a/docs/configurator/styles.css
+++ b/docs/configurator/styles.css
@@ -64,6 +64,13 @@ button {
   cursor: pointer;
 }
 button:hover { background: #0d9488; }
+
+.button-green {
+  background: #15803d;
+}
+.button-green:hover {
+  background: #16a34a;
+}
 .code-block {
   background: #0b1220;
   border: 1px solid #374151;


### PR DESCRIPTION
### Motivation
- Provide a single action to download the complete generated output as a ZIP containing the top-level files and the cores folder, while preserving the existing cores-only ZIP option.

### Description
- Added a new green button at the start of the Generated XML controls with `id="downloadAllFiles"` and label `Download all files (.zip)` in `docs/configurator/index.html`.
- Added `.button-green` styles to `docs/configurator/styles.css` to make the new button green and match the requested visual placement.
- Implemented a new download handler in `docs/configurator/app.js` that creates a ZIP containing `ShipCoreConfig_No_Core.xml`, `ShipCoreConfig_Groups.xml`, and `ShipCoreConfig_Manifest.xml` at the ZIP root plus all core XMLs under `Cores/`, and triggers `downloadBlob("ShipCore_All_Files.zip", ...)`.
- Left the existing `downloadCores` behavior unchanged so the “Download cores only” option still produces the cores-only ZIP in `Cores/`.

### Testing
- Ran `node --check docs/configurator/app.js` to validate JavaScript syntax and it succeeded.
- Attempted an automated Playwright screenshot of the configurator UI to visually validate the button placement, but the Chromium launch crashed in this environment (SIGSEGV), so the UI screenshot step failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab1ae8af0c8323b5ddfe707436ff8a)