### PR TITLE
Allow push-triggered Steam Workshop upload and default SBMI profile

### DIFF
--- a/.github/workflows/steam-workshop-upload.yml
+++ b/.github/workflows/steam-workshop-upload.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate required secrets
-        if: ${{ github.event.inputs.target == 'both' || github.event.inputs.target == matrix.key }}
+        if: ${{ github.event_name == 'push' || github.event.inputs.target == 'both' || github.event.inputs.target == matrix.key }}
         env:
           STEAM_CONFIG_VDF: ${{ secrets.STEAM_CONFIG_VDF }}
         run: |
@@ -57,9 +57,9 @@ jobs:
           echo "Using cached SteamCMD host config authentication for workshop upload."
 
       - name: Build upload content from src only
-        if: ${{ github.event.inputs.target == 'both' || github.event.inputs.target == matrix.key }}
+        if: ${{ github.event_name == 'push' || github.event.inputs.target == 'both' || github.event.inputs.target == matrix.key }}
         env:
-          SBMI_PROFILE: ${{ github.event.inputs.sbmi_profile }}
+          SBMI_PROFILE: ${{ github.event.inputs.sbmi_profile || 'beta' }}
         run: |
           set -euo pipefail
           STAGING="${RUNNER_TEMP}/${{ matrix.mod_dir }}-upload"
@@ -87,17 +87,17 @@ jobs:
           echo "STAGING_DIR=$STAGING" >> "$GITHUB_ENV"
 
       - name: Setup SteamCMD
-        if: ${{ github.event.inputs.target == 'both' || github.event.inputs.target == matrix.key }}
+        if: ${{ github.event_name == 'push' || github.event.inputs.target == 'both' || github.event.inputs.target == matrix.key }}
         uses: andriivitiv/setup-steamcmd@v1.2.0
 
       - name: Prune SBMI profile files from upload staging
-        if: ${{ github.event.inputs.target == 'both' || github.event.inputs.target == matrix.key }}
+        if: ${{ github.event_name == 'push' || github.event.inputs.target == 'both' || github.event.inputs.target == matrix.key }}
         run: |
           set -euo pipefail
           rm -f "$STAGING_DIR/modinfo.sbmi.beta" "$STAGING_DIR/modinfo.sbmi.main"
 
       - name: Create SteamCMD upload script
-        if: ${{ github.event.inputs.target == 'both' || github.event.inputs.target == matrix.key }}
+        if: ${{ github.event_name == 'push' || github.event.inputs.target == 'both' || github.event.inputs.target == matrix.key }}
         run: |
           cat > "$RUNNER_TEMP/workshop_item.vdf" <<EOF
           "workshopitem"
@@ -110,7 +110,7 @@ jobs:
           EOF
 
       - name: Install SteamCMD cached credentials config
-        if: ${{ github.event.inputs.target == 'both' || github.event.inputs.target == matrix.key }}
+        if: ${{ github.event_name == 'push' || github.event.inputs.target == 'both' || github.event.inputs.target == matrix.key }}
         env:
           STEAM_CONFIG_VDF: ${{ secrets.STEAM_CONFIG_VDF }}
         run: |
@@ -123,7 +123,7 @@ jobs:
           echo "Wrote Steam cached credentials config to: $HOME/Steam/config/config.vdf"
 
       - name: Upload to Steam Workshop item
-        if: ${{ github.event.inputs.target == 'both' || github.event.inputs.target == matrix.key }}
+        if: ${{ github.event_name == 'push' || github.event.inputs.target == 'both' || github.event.inputs.target == matrix.key }}
         env:
           STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
         run: |


### PR DESCRIPTION
### Motivation
- The Steam Workshop upload workflow skipped running on `push` because several step `if` guards only evaluated `workflow_dispatch` inputs, so automatic pushes didn't satisfy the conditions. 
- Push-triggered runs do not provide `workflow_dispatch` inputs, so a safe default SBMI profile is required to resolve a profile file during automatic uploads.

### Description
- Updated `.github/workflows/steam-workshop-upload.yml` to allow upload-path steps to run when `github.event_name == 'push'` in addition to the existing `workflow_dispatch` input checks. 
- Defaulted the `SBMI_PROFILE` environment value to `'beta'` for runs that lack `workflow_dispatch` inputs by changing `SBMI_PROFILE: ${{ github.event.inputs.sbmi_profile }}` to `SBMI_PROFILE: ${{ github.event.inputs.sbmi_profile || 'beta' }}`. 
- Applied the same `push`-aware `if` guard to all upload-relevant steps including secret validation, staging/build steps, SteamCMD setup, pruning, script creation, credential install, and upload execution. 
- The only modified file is ` .github/workflows/steam-workshop-upload.yml`.

### Testing
- Ran `git diff --check` which reported no whitespace errors and completed successfully. 
- Attempted YAML validation via `python3` using `yaml.safe_load`, but the environment lacks the `PyYAML` module which raised `ModuleNotFoundError`, so full YAML parsing was not performed. 
- Attempted to run `actionlint` but it is not installed in the environment, so workflow linting was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba66d4219483238108394ee042f272)