### PR TITLE
Avoid concurrent enumeration of GridDictionary in GroupComponent

### DIFF
--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Abilities.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Abilities.cs
@@ -21,7 +21,7 @@ namespace ShipCoreFramework
                 }
 
                 var modifiers = _activeDefenseEnabled ? GetActiveDefenseModifiers() : GetPassiveDefenseModifiers();
-                foreach (var kvp in GridDictionary) CubeGridModifiers.DefenseModifiers[kvp.Key.EntityId] = modifiers;
+                foreach (var kvp in GetGridEntriesCopy()) CubeGridModifiers.DefenseModifiers[kvp.Key.EntityId] = modifiers;
             }
             else
             {
@@ -71,13 +71,13 @@ namespace ShipCoreFramework
                 }
 
                 var modifiers = _activeDefenseEnabled ? GetActiveDefenseModifiers() : GetPassiveDefenseModifiers();
-                foreach (var kvp in GridDictionary) CubeGridModifiers.DefenseModifiers[kvp.Key.EntityId] = modifiers;
+                foreach (var kvp in GetGridEntriesCopy()) CubeGridModifiers.DefenseModifiers[kvp.Key.EntityId] = modifiers;
             }
         }
 
         private bool HasWorkingBeacon()
         {
-            foreach (var grid in GridDictionary.Keys)
+            foreach (var grid in GetGridsCopy())
             {
                 if (grid == null || grid.MarkedForClose || grid.Closed) continue;
 
@@ -92,7 +92,7 @@ namespace ShipCoreFramework
 
         internal void ApplyModifiers(GridModifiers modifiers)
         {
-            foreach (var kvp in GridDictionary)
+            foreach (var kvp in GetGridEntriesCopy())
             {
                 var blocksCopy = kvp.Value.GetBlocksCopy();
                 foreach (var block in blocksCopy)
@@ -106,7 +106,7 @@ namespace ShipCoreFramework
         public void DefenseValuesChanged()
         {
             var modifiers = GetActiveDefenseModifiers();
-            foreach (var kvp in GridDictionary) CubeGridModifiers.DefenseModifiers[kvp.Key.EntityId] = modifiers;
+            foreach (var kvp in GetGridEntriesCopy()) CubeGridModifiers.DefenseModifiers[kvp.Key.EntityId] = modifiers;
         }
 
         internal void RunBoostTimerTick()
@@ -141,7 +141,7 @@ namespace ShipCoreFramework
                 _activeDefenseEnabled = false;
 
                 var modifiers = GetPassiveDefenseModifiers();
-                foreach (var kvp in GridDictionary) CubeGridModifiers.DefenseModifiers[kvp.Key.EntityId] = modifiers;
+                foreach (var kvp in GetGridEntriesCopy()) CubeGridModifiers.DefenseModifiers[kvp.Key.EntityId] = modifiers;
 
                 _activeDefenseCooldownTimer = ActiveDefenseCoolDown * 60f;
                 Utils.ShowNotification("Active Defense Disengaged! Cooldown started.", 1000);
@@ -183,7 +183,7 @@ namespace ShipCoreFramework
             _activeDefenseDurationTimer = ActiveDefenseDuration * 60f;
 
             var modifiers = GetActiveDefenseModifiers();
-            foreach (var kvp in GridDictionary) CubeGridModifiers.DefenseModifiers[kvp.Key.EntityId] = modifiers;
+            foreach (var kvp in GetGridEntriesCopy()) CubeGridModifiers.DefenseModifiers[kvp.Key.EntityId] = modifiers;
 
             Utils.ShowNotification("Active Defense Engaged!", 1000);
 

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Connectors.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Connectors.cs
@@ -34,7 +34,7 @@ namespace ShipCoreFramework
         {
             _connectedNoCoreGroups.Clear();
 
-            foreach (var grid in GridDictionary.Keys)
+            foreach (var grid in GetGridsCopy())
             {
                 if (grid == null || grid.MarkedForClose || grid.Closed) continue;
 
@@ -90,7 +90,7 @@ namespace ShipCoreFramework
                 if (!Session.GroupDict.TryGetValue(otherGroupData, out otherComp) || otherComp == null) continue;
                 if (otherComp.MainCoreComponent != null) continue;
 
-                foreach (var otherGridComp in otherComp.GridDictionary.Values)
+                foreach (var otherGridComp in otherComp.GetGridComponentsCopy())
                 {
                     var blocksCopy = otherGridComp.GetBlocksCopy();
                     foreach (var block in blocksCopy)

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Lifecycle.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Lifecycle.cs
@@ -20,7 +20,7 @@ namespace ShipCoreFramework
                 if (startGrid.IsPreview) return;
 
                 var gridComp = new GridComponent();
-                GridDictionary.Add(startGrid, gridComp);
+                TryAddGridComponent(startGrid, gridComp);
                 gridComp.Init(startGrid, MyGroup);
             }
         }
@@ -78,10 +78,10 @@ namespace ShipCoreFramework
             var g = grid as MyCubeGrid;
             if (g == null || g.IsPreview) return;
 
-            if (GridDictionary.ContainsKey(g)) return;
+            if (TryGetGridComponent(g, out _)) return;
             var gc = new GridComponent();
             gc.Init(g, addedTo);
-            GridDictionary.Add(g, gc);
+            TryAddGridComponent(g, gc);
 
             Utils.Log($"OnGridAdded: {grid.EntityId}, {OwnerId}, {grid.CustomName}", 2);
             MyAPIGateway.Utilities.InvokeOnGameThread(() =>
@@ -113,7 +113,7 @@ namespace ShipCoreFramework
             if (g == null || g.IsPreview) return;
 
             GridComponent comp;
-            if (GridDictionary.TryGetValue(g, out comp))
+            if (TryGetGridComponent(g, out comp))
             {
                 if (MainCoreComponent?.GridComponent.Grid.EntityId == g.EntityId)
                 {
@@ -124,10 +124,10 @@ namespace ShipCoreFramework
                 }
 
                 comp.Clean();
-                GridDictionary.Remove(g);
+                RemoveGridComponent(g);
             }
 
-            if (GridDictionary.Count == 0)
+            if (GridCount == 0)
             {
                 _closing = true;
                 return;
@@ -158,7 +158,7 @@ namespace ShipCoreFramework
 
         internal void SyncBeaconComponents()
         {
-            foreach (var gridComponent in GridDictionary.Values)
+            foreach (var gridComponent in GetGridComponentsCopy())
                 gridComponent.SyncBeaconComponents();
         }
 
@@ -175,8 +175,8 @@ namespace ShipCoreFramework
                 Utils.Log("LOGGING EXCEPTION (most likely due to closure of world): " + e, 1);
             }
 
-            foreach (var kvp in GridDictionary) kvp.Value.Clean();
-            GridDictionary.Clear();
+            foreach (var kvp in GetGridEntriesCopy()) kvp.Value.Clean();
+            ClearGridDictionary();
             Limits.Clear();
         }
     }

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Limits.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Limits.cs
@@ -172,7 +172,7 @@ namespace ShipCoreFramework
         {
             Limits.Clear();
 
-            foreach (var comp in GridDictionary.Values)
+            foreach (var comp in GetGridComponentsCopy())
             {
                 comp.RecalculateLimits(this);
                 foreach (var gridLimitKv in comp.Limits)

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Ownership.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Ownership.cs
@@ -86,7 +86,7 @@ namespace ShipCoreFramework
         private long GetRepresentativeGridId()
         {
             var main = MainCoreComponent?.GridComponent?.Grid;
-            var grid = main ?? GridDictionary.Keys.FirstOrDefault();
+            var grid = main ?? GetGridsCopy().FirstOrDefault();
             return grid?.EntityId ?? 0;
         }
     }

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Upgrades.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Upgrades.cs
@@ -8,7 +8,7 @@ namespace ShipCoreFramework
     {
         private IEnumerable<UpgradeModuleComponent> GetUpgradeModules()
         {
-            return GridDictionary.Values.SelectMany(gridComponent => gridComponent.GetUpgradeModuleComponentsCopy());
+            return GetGridComponentsCopy().SelectMany(gridComponent => gridComponent.GetUpgradeModuleComponentsCopy());
         }
 
         internal IEnumerable<UpgradeModuleComponent> GetMainCoreUpgradeModules(bool requireFunctionalForEffects)

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.cs
@@ -9,20 +9,21 @@ namespace ShipCoreFramework
     public partial class GroupComponent
     {
         private const int MinimumBlocksRecheckIntervalTicks = 10 * 60 * 60;
+        private readonly object _gridDictionaryLock = new object();
 
         internal ShipCore ShipCore => Session.Config.GetShipCoreByTypeId(MainCoreComponent?.SubtypeId ?? string.Empty);
         internal GridModifiers Modifiers => CubeGridModifiers.GetActiveModifiers(this);
         internal SpeedModifiers SpeedModifiers => CubeGridModifiers.GetActiveSpeedModifiers(this);
 
         internal IMyFaction OwningFaction => MyAPIGateway.Session.Factions.TryGetPlayerFaction(OwnerId);
-        internal int GroupBlocksCount => GridDictionary.Sum(g => g.Key.BlocksCount);
-        internal int GroupPCU => GridDictionary.Sum(g => g.Key.BlocksPCU);
+        internal int GroupBlocksCount => GetGridEntriesCopy().Sum(g => g.Key.BlocksCount);
+        internal int GroupPCU => GetGridEntriesCopy().Sum(g => g.Key.BlocksPCU);
         internal float GroupMass {
             get
             {
                 float dryMass = 0;
                 float wetMass = 0;
-                GridDictionary.Keys.FirstOrDefault()?.GetCurrentMass(out dryMass, out wetMass, GridLinkTypeEnum.Mechanical);
+                GetGridsCopy().FirstOrDefault()?.GetCurrentMass(out dryMass, out wetMass, GridLinkTypeEnum.Mechanical);
                 return Session.Config.MassTypeMode == MassTypeMode.Dry ? dryMass : wetMass;
             }
         }
@@ -38,7 +39,76 @@ namespace ShipCoreFramework
             new Dictionary<MyCubeGrid, GridComponent>();
 
         internal Dictionary<IMyCubeBlock, CoreComponent> CoreDictionary =>
-            Utils.Flatten(GridDictionary.Values, component => component.CoreDictionary);
+            Utils.Flatten(GetGridComponentsCopy(), component => component.CoreDictionary);
+
+        internal bool TryAddGridComponent(MyCubeGrid grid, GridComponent gridComponent)
+        {
+            lock (_gridDictionaryLock)
+            {
+                if (GridDictionary.ContainsKey(grid)) return false;
+                GridDictionary.Add(grid, gridComponent);
+                return true;
+            }
+        }
+
+        internal bool TryGetGridComponent(MyCubeGrid grid, out GridComponent component)
+        {
+            lock (_gridDictionaryLock)
+            {
+                return GridDictionary.TryGetValue(grid, out component);
+            }
+        }
+
+        internal bool RemoveGridComponent(MyCubeGrid grid)
+        {
+            lock (_gridDictionaryLock)
+            {
+                return GridDictionary.Remove(grid);
+            }
+        }
+
+        internal int GridCount
+        {
+            get
+            {
+                lock (_gridDictionaryLock)
+                {
+                    return GridDictionary.Count;
+                }
+            }
+        }
+
+        internal void ClearGridDictionary()
+        {
+            lock (_gridDictionaryLock)
+            {
+                GridDictionary.Clear();
+            }
+        }
+
+        internal List<KeyValuePair<MyCubeGrid, GridComponent>> GetGridEntriesCopy()
+        {
+            lock (_gridDictionaryLock)
+            {
+                return new List<KeyValuePair<MyCubeGrid, GridComponent>>(GridDictionary);
+            }
+        }
+
+        internal List<MyCubeGrid> GetGridsCopy()
+        {
+            lock (_gridDictionaryLock)
+            {
+                return new List<MyCubeGrid>(GridDictionary.Keys);
+            }
+        }
+
+        internal List<GridComponent> GetGridComponentsCopy()
+        {
+            lock (_gridDictionaryLock)
+            {
+                return new List<GridComponent>(GridDictionary.Values);
+            }
+        }
 
         internal bool PunishModifiers;
         internal bool PunishSpeed;


### PR DESCRIPTION
### Motivation
- Prevent `InvalidOperationException: Collection was modified; enumeration operation may not execute` caused by concurrent iteration of `GridDictionary` while other threads add/remove grids. 
- Preserve the current multithreaded initialization and background processing while providing a safe synchronization boundary for group-level grid access.

### Description
- Introduced a lock object ` _gridDictionaryLock` and a small thread-safe API around the map: `TryAddGridComponent`, `TryGetGridComponent`, `RemoveGridComponent`, `ClearGridDictionary`, and `GridCount` to serialize mutations to `GridDictionary`.
- Added snapshot helper accessors `GetGridEntriesCopy`, `GetGridsCopy`, and `GetGridComponentsCopy` that return locked copies for safe enumeration without holding the lock for long.
- Replaced direct enumerations and direct `GridDictionary` reads/writes in hot paths to use the snapshot helpers or lock-safe mutators; updated usages in `InitGrids`, `OnGridAdded`, `OnGridRemoved`, `Clean`, `ApplyModifiers`, limits recalculation, connector handling, upgrades, representative grid lookup, and defense updates.
- Key changed files: `GroupComponent.cs`, `GroupComponent.Lifecycle.cs`, `GroupComponent.Abilities.cs`, `GroupComponent.Connectors.cs`, `GroupComponent.Limits.cs`, `GroupComponent.Upgrades.cs`, and `GroupComponent.Ownership.cs`.

### Testing
- Ran an automated code search (`rg`) to verify occurrences of direct `GridDictionary` enumeration were replaced with snapshot helpers, and that mutation points use the lock-safe helpers (verification succeeded).
- Attempted automated build with `dotnet build ShipCoreSystem.sln`, but the environment does not have `dotnet` installed so a build could not be executed (build failed due to missing tool).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2dc96a2f4832387d62699d63a6ece)