### PR TITLE
Use thread-safe ConcurrentDictionary for grid components and add helper accessors

### DIFF
--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Lifecycle.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Lifecycle.cs
@@ -20,7 +20,7 @@ namespace ShipCoreFramework
                 if (startGrid.IsPreview) return;
 
                 var gridComp = new GridComponent();
-                GridDictionary.Add(startGrid, gridComp);
+                TryAddGridComponent(startGrid, gridComp);
                 gridComp.Init(startGrid, MyGroup);
             }
         }
@@ -78,10 +78,10 @@ namespace ShipCoreFramework
             var g = grid as MyCubeGrid;
             if (g == null || g.IsPreview) return;
 
-            if (GridDictionary.ContainsKey(g)) return;
+            if (TryGetGridComponent(g, out _)) return;
             var gc = new GridComponent();
             gc.Init(g, addedTo);
-            GridDictionary.Add(g, gc);
+            TryAddGridComponent(g, gc);
 
             Utils.Log($"OnGridAdded: {grid.EntityId}, {OwnerId}, {grid.CustomName}", 2);
             MyAPIGateway.Utilities.InvokeOnGameThread(() =>
@@ -113,7 +113,7 @@ namespace ShipCoreFramework
             if (g == null || g.IsPreview) return;
 
             GridComponent comp;
-            if (GridDictionary.TryGetValue(g, out comp))
+            if (TryGetGridComponent(g, out comp))
             {
                 if (MainCoreComponent?.GridComponent.Grid.EntityId == g.EntityId)
                 {
@@ -124,10 +124,10 @@ namespace ShipCoreFramework
                 }
 
                 comp.Clean();
-                GridDictionary.Remove(g);
+                RemoveGridComponent(g);
             }
 
-            if (GridDictionary.Count == 0)
+            if (GridCount == 0)
             {
                 _closing = true;
                 return;
@@ -176,7 +176,7 @@ namespace ShipCoreFramework
             }
 
             foreach (var kvp in GridDictionary) kvp.Value.Clean();
-            GridDictionary.Clear();
+            ClearGridDictionary();
             Limits.Clear();
         }
     }

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Sandbox.ModAPI;
@@ -34,11 +35,36 @@ namespace ShipCoreFramework
 
         internal readonly Dictionary<BlockLimit, LimitBucket> Limits = new Dictionary<BlockLimit, LimitBucket>();
 
-        internal readonly Dictionary<MyCubeGrid, GridComponent> GridDictionary =
-            new Dictionary<MyCubeGrid, GridComponent>();
+        internal readonly ConcurrentDictionary<MyCubeGrid, GridComponent> GridDictionary =
+            new ConcurrentDictionary<MyCubeGrid, GridComponent>();
 
         internal Dictionary<IMyCubeBlock, CoreComponent> CoreDictionary =>
             Utils.Flatten(GridDictionary.Values, component => component.CoreDictionary);
+
+        internal bool TryAddGridComponent(MyCubeGrid grid, GridComponent gridComponent)
+        {
+            return GridDictionary.TryAdd(grid, gridComponent);
+        }
+
+        internal bool TryGetGridComponent(MyCubeGrid grid, out GridComponent component)
+        {
+            return GridDictionary.TryGetValue(grid, out component);
+        }
+
+        internal bool RemoveGridComponent(MyCubeGrid grid)
+        {
+            return GridDictionary.TryRemove(grid, out _);
+        }
+
+        internal int GridCount
+        {
+            get { return GridDictionary.Count; }
+        }
+
+        internal void ClearGridDictionary()
+        {
+            GridDictionary.Clear();
+        }
 
         internal bool PunishModifiers;
         internal bool PunishSpeed;


### PR DESCRIPTION
### Motivation

- Make grid-component storage thread-safe and reduce race conditions when grids are added/removed concurrently by using a concurrent collection.
- Encapsulate common dictionary operations behind helper methods to centralize behavior and simplify call-sites in lifecycle code.

### Description

- Replaced `Dictionary<MyCubeGrid, GridComponent>` with `ConcurrentDictionary<MyCubeGrid, GridComponent>` and added `using System.Collections.Concurrent`.
- Added helper methods `TryAddGridComponent`, `TryGetGridComponent`, `RemoveGridComponent`, `ClearGridDictionary` and the `GridCount` property to manage the grid map.
- Updated `GroupComponent.Lifecycle.cs` to use the new helpers instead of direct dictionary access in `InitGrids`, `OnGridAdded`, `OnGridRemoved`, and `Clean`.
- Left iteration usages (e.g. `GridDictionary.Values`) intact while centralizing add/remove/clear semantics.

### Testing

- Solution was built to verify the changes compile successfully.
- No automated unit tests were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2dc96a2f4832387d62699d63a6ece)