### PR TITLE
Gate Steam Workshop uploads to only changed mod src paths

### DIFF
--- a/.github/workflows/steam-workshop-upload.yml
+++ b/.github/workflows/steam-workshop-upload.yml
@@ -46,8 +46,38 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Determine whether this matrix target should upload
+        id: matrix_gate
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          SHOULD_UPLOAD=false
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            if [ "${{ github.event.inputs.target }}" = "both" ] || [ "${{ github.event.inputs.target }}" = "${{ matrix.key }}" ]; then
+              SHOULD_UPLOAD=true
+            fi
+          else
+            BEFORE_SHA="${{ github.event.before }}"
+            CURRENT_SHA="${{ github.sha }}"
+
+            if [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
+              if git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA" -- "${{ matrix.src_dir }}/" | grep -q .; then
+                SHOULD_UPLOAD=true
+              fi
+            else
+              if git ls-tree -r --name-only "$CURRENT_SHA" -- "${{ matrix.src_dir }}/" | grep -q .; then
+                SHOULD_UPLOAD=true
+              fi
+            fi
+          fi
+
+          echo "should_upload=$SHOULD_UPLOAD" >> "$GITHUB_OUTPUT"
+          echo "Matrix target '${{ matrix.key }}' upload decision: $SHOULD_UPLOAD"
+
       - name: Validate required secrets
-        if: ${{ github.event_name == 'push' || github.event.inputs.target == 'both' || github.event.inputs.target == matrix.key }}
+        if: ${{ steps.matrix_gate.outputs.should_upload == 'true' }}
         env:
           STEAM_CONFIG_VDF: ${{ secrets.STEAM_CONFIG_VDF }}
         run: |
@@ -57,7 +87,7 @@ jobs:
           echo "Using cached SteamCMD host config authentication for workshop upload."
 
       - name: Build upload content from src only
-        if: ${{ github.event_name == 'push' || github.event.inputs.target == 'both' || github.event.inputs.target == matrix.key }}
+        if: ${{ steps.matrix_gate.outputs.should_upload == 'true' }}
         env:
           SBMI_PROFILE: ${{ github.event.inputs.sbmi_profile || 'beta' }}
         run: |
@@ -87,17 +117,17 @@ jobs:
           echo "STAGING_DIR=$STAGING" >> "$GITHUB_ENV"
 
       - name: Setup SteamCMD
-        if: ${{ github.event_name == 'push' || github.event.inputs.target == 'both' || github.event.inputs.target == matrix.key }}
+        if: ${{ steps.matrix_gate.outputs.should_upload == 'true' }}
         uses: andriivitiv/setup-steamcmd@v1.2.0
 
       - name: Prune SBMI profile files from upload staging
-        if: ${{ github.event_name == 'push' || github.event.inputs.target == 'both' || github.event.inputs.target == matrix.key }}
+        if: ${{ steps.matrix_gate.outputs.should_upload == 'true' }}
         run: |
           set -euo pipefail
           rm -f "$STAGING_DIR/modinfo.sbmi.beta" "$STAGING_DIR/modinfo.sbmi.main"
 
       - name: Create SteamCMD upload script
-        if: ${{ github.event_name == 'push' || github.event.inputs.target == 'both' || github.event.inputs.target == matrix.key }}
+        if: ${{ steps.matrix_gate.outputs.should_upload == 'true' }}
         run: |
           cat > "$RUNNER_TEMP/workshop_item.vdf" <<EOF
           "workshopitem"
@@ -110,7 +140,7 @@ jobs:
           EOF
 
       - name: Install SteamCMD cached credentials config
-        if: ${{ github.event_name == 'push' || github.event.inputs.target == 'both' || github.event.inputs.target == matrix.key }}
+        if: ${{ steps.matrix_gate.outputs.should_upload == 'true' }}
         env:
           STEAM_CONFIG_VDF: ${{ secrets.STEAM_CONFIG_VDF }}
         run: |
@@ -123,7 +153,7 @@ jobs:
           echo "Wrote Steam cached credentials config to: $HOME/Steam/config/config.vdf"
 
       - name: Upload to Steam Workshop item
-        if: ${{ github.event_name == 'push' || github.event.inputs.target == 'both' || github.event.inputs.target == matrix.key }}
+        if: ${{ steps.matrix_gate.outputs.should_upload == 'true' }}
         env:
           STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
         run: |


### PR DESCRIPTION
### Motivation
- Prevent the Steam Workshop upload job from executing for both matrix targets when only one mod’s sources changed by ensuring uploads run only for the affected mod.
- Preserve existing `workflow_dispatch` behavior so manual runs using `target` or `both` still function as before.

### Description
- Added a matrix gate step `Determine whether this matrix target should upload` that sets `should_upload` and writes it to `GITHUB_OUTPUT` for downstream gating.
- For `push` events the gate checks changed files under the matrix `src_dir` by using `git diff --name-only` when `github.event.before` is available or `git ls-tree` for the current SHA otherwise, and for `workflow_dispatch` it honors the `target` input (including `both`).
- Replaced the previous broad `if:` conditions with `if: ${{ steps.matrix_gate.outputs.should_upload == 'true' }}` on all upload-related steps so only the selected matrix target proceeds to validate secrets, build staging, and upload.

### Testing
- Ran `git diff --check` which passed.
- Attempted to parse the workflow with Python/YAML but the run failed because `PyYAML` is not installed in the environment.
- Attempted `actionlint` but it was not available in the environment, so linting could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2f4e488dc8323bd98be9ed9501685)