### PR TITLE
Grey out and clear disabled no-core output path

### DIFF
--- a/docs/configurator/app.js
+++ b/docs/configurator/app.js
@@ -641,6 +641,9 @@ function renderShipCores() {
   const core = getCoreBySelectorIndex(coreIndex);
   if (!core) return;
   const isNoCore = coreIndex === 0;
+  if (isNoCore) {
+    core.outputDirectory = "";
+  }
   const expandedLimitPanels = normalizeExpandedLimitPanelsForCore(coreIndex);
 
   ids("shipCores").innerHTML = `
@@ -648,7 +651,7 @@ function renderShipCores() {
       <div class="row wrap">
         <label class="inline">Core Subtype <input data-action="core-subtype" data-c="${coreIndex}" class="small" placeholder="SubtypeId" value="${escapeXml(core.subtypeId)}" /></label>
         <label class="inline">Core Name <input data-action="core-unique" data-c="${coreIndex}" class="small" placeholder="UniqueName" value="${escapeXml(core.uniqueName)}" /></label>
-        <label class="inline">Output Folder <input data-action="core-output-directory" data-c="${coreIndex}" class="small" placeholder="Data/Cores/" value="${escapeXml(core.outputDirectory)}" ${isNoCore ? "disabled title=\"No Core output always stays in the root folder.\"" : ""} /></label>
+        <label class="inline">Output Folder <input data-action="core-output-directory" data-c="${coreIndex}" class="small${isNoCore ? " no-core-output-disabled" : ""}" placeholder="Data/Cores/" value="${escapeXml(isNoCore ? "" : core.outputDirectory)}" ${isNoCore ? "disabled title=\"No Core output always stays in the root folder.\"" : ""} /></label>
         <label class="inline">Mobility
           <select data-action="core-mobility" data-c="${coreIndex}" class="small">
             ${["Static", "Mobile", "Both"].map((value) => `<option ${core.mobilityType === value ? "selected" : ""}>${value}</option>`).join("")}

--- a/docs/configurator/styles.css
+++ b/docs/configurator/styles.css
@@ -107,6 +107,10 @@ button:hover { background: #0d9488; }
 }
 .card h4 { margin: 0.25rem 0 0.5rem; }
 .small { width: 220px; }
+.no-core-output-disabled {
+  background: #1f2937;
+  color: #9ca3af;
+}
 .inline { display: inline-flex; gap: 0.5rem; align-items: center; margin-right: 1rem; }
 .menu-controls {
   display: flex;


### PR DESCRIPTION
### Motivation
- Prevent stale output paths from appearing when the special "No Core" entry is selected so users are not misled by an editable-looking value.
- Make the disabled No Core output field visually distinct by slightly greying it out to improve UI clarity.

### Description
- Updated `docs/configurator/app.js` to force-clear `core.outputDirectory` when the selected core is the No Core entry and to render the Output Folder input with an empty value for No Core (`value="${escapeXml(isNoCore ? "" : core.outputDirectory)}"`).
- Added a conditional input class so the disabled No Core output input receives `no-core-output-disabled` when `isNoCore` is true (`class="small${isNoCore ? " no-core-output-disabled" : ""}"`).
- Added a `.no-core-output-disabled` rule to `docs/configurator/styles.css` that applies a slightly darker background and muted text color so the disabled input appears greyed out.

### Testing
- Ran a JavaScript syntax check with `node --check docs/configurator/app.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c30ff3030883238d54ed4cc283746f)