### PR TITLE
Fix no-core output folder placeholder in configurator

### DIFF
--- a/docs/configurator/app.js
+++ b/docs/configurator/app.js
@@ -651,7 +651,7 @@ function renderShipCores() {
       <div class="row wrap">
         <label class="inline">Core Subtype <input data-action="core-subtype" data-c="${coreIndex}" class="small" placeholder="SubtypeId" value="${escapeXml(core.subtypeId)}" /></label>
         <label class="inline">Core Name <input data-action="core-unique" data-c="${coreIndex}" class="small" placeholder="UniqueName" value="${escapeXml(core.uniqueName)}" /></label>
-        <label class="inline">Output Folder <input data-action="core-output-directory" data-c="${coreIndex}" class="small${isNoCore ? " no-core-output-disabled" : ""}" placeholder="Data/Cores/" value="${escapeXml(isNoCore ? "" : core.outputDirectory)}" ${isNoCore ? "disabled title=\"No Core output always stays in the root folder.\"" : ""} /></label>
+        <label class="inline">Output Folder <input data-action="core-output-directory" data-c="${coreIndex}" class="small${isNoCore ? " no-core-output-disabled" : ""}" placeholder="${isNoCore ? "" : "Data/Cores/"}" value="${escapeXml(isNoCore ? "" : core.outputDirectory)}" ${isNoCore ? "disabled title=\"No Core output always stays in the root folder.\"" : ""} /></label>
         <label class="inline">Mobility
           <select data-action="core-mobility" data-c="${coreIndex}" class="small">
             ${["Static", "Mobile", "Both"].map((value) => `<option ${core.mobilityType === value ? "selected" : ""}>${value}</option>`).join("")}


### PR DESCRIPTION
### Motivation
- Make the configurator UI consistent by showing an empty placeholder for the "No Core" config's Output Folder because the field is disabled and the underlying `outputDirectory` is enforced empty.

### Description
- Update `renderShipCores()` in `docs/configurator/app.js` to set the `placeholder` to `""` when `isNoCore` and to `"Data/Cores/"` otherwise.

### Testing
- Ran `git diff -- docs/configurator/app.js` to inspect the change and `git status --short` to confirm the modified file, both succeeded.
- Committed the change with `git commit` and no automated test suite was executed for this UI-only tweak.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c311b1e7f88323bc059cb190e73492)