### PR TITLE
Guard beacon default restore during world unload

### DIFF
--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/BeaconComponent.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/BeaconComponent.cs
@@ -40,6 +40,7 @@ namespace ShipCoreFramework
             BeaconBlock.IsWorkingChanged -= OnModuleWorkingChanged;
             BeaconBlock.PropertiesChanged -= OnPropertiesChanged;
             RestoreDefaults();
+            BeaconBlock = null;
             _groupComponent.EnforceOverCapacity();
         }
         private void OnModuleWorkingChanged(IMyCubeBlock obj)
@@ -73,7 +74,7 @@ namespace ShipCoreFramework
 
         internal void SyncForceBroadcast()
         {
-            if (BeaconBlock == null || !_groupComponent.ShipCore.ForceBroadCast) return;
+            if (!IsBeaconAvailable() || !_groupComponent.ShipCore.ForceBroadCast) return;
 
             if (!ShouldForceBroadcast())
             {
@@ -99,7 +100,7 @@ namespace ShipCoreFramework
 
         private void CaptureDefaults(bool overwrite = true)
         {
-            if (BeaconBlock == null) return;
+            if (!IsBeaconAvailable()) return;
             if (_hasCapturedDefaults && !overwrite) return;
 
             _defaultRadius = BeaconBlock.GetValue<float>("Radius");
@@ -109,7 +110,7 @@ namespace ShipCoreFramework
 
         private void RestoreDefaults()
         {
-            if (BeaconBlock == null || !_hasCapturedDefaults) return;
+            if (!IsBeaconAvailable() || !_hasCapturedDefaults) return;
 
             _isUpdatingProperties = true;
             try
@@ -121,6 +122,16 @@ namespace ShipCoreFramework
             {
                 _isUpdatingProperties = false;
             }
+        }
+
+        private bool IsBeaconAvailable()
+        {
+            return BeaconBlock != null
+                && !BeaconBlock.MarkedForClose
+                && !BeaconBlock.Closed
+                && BeaconBlock.CubeGrid != null
+                && !BeaconBlock.CubeGrid.MarkedForClose
+                && !BeaconBlock.CubeGrid.Closed;
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent a `NullReferenceException` during world unload when restoring beacon properties while the beacon or its grid is closing or already closed.
- Avoid calling into `MyBeacon.ChangeRadius()` (via terminal writes) on invalid entities which caused a fatal crash during session unload.

### Description
- Added a helper `IsBeaconAvailable()` that verifies `BeaconBlock` and its `CubeGrid` are not `MarkedForClose` or `Closed` before writing properties.
- Replaced direct `BeaconBlock == null` checks with `IsBeaconAvailable()` in `SyncForceBroadcast`, `CaptureDefaults`, and `RestoreDefaults` to guard property reads/writes.
- Null out `BeaconBlock` in `Clean()` after unhooking events and restoring defaults to prevent later accesses to a stale block reference.

### Testing
- Attempted an automated build with `dotnet build ShipCoreSystem.sln`, but the build could not be run in this environment because `dotnet` is not installed and the build step failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c429571e00832394cb837bbf89c10a)