### PR TITLE
Fix Steam workshop upload gating when github.event.before SHA is missing

### DIFF
--- a/.github/workflows/steam-workshop-upload.yml
+++ b/.github/workflows/steam-workshop-upload.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Determine whether this matrix target should upload
         id: matrix_gate
@@ -63,7 +65,12 @@ jobs:
             CURRENT_SHA="${{ github.sha }}"
 
             if [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
-              if git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA" -- "${{ matrix.src_dir }}/" | grep -q .; then
+              if git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
+                if git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA" -- "${{ matrix.src_dir }}/" | grep -q .; then
+                  SHOULD_UPLOAD=true
+                fi
+              else
+                echo "Previous SHA '$BEFORE_SHA' is not available in this checkout. Forcing upload to avoid missing workshop updates."
                 SHOULD_UPLOAD=true
               fi
             else


### PR DESCRIPTION
### Motivation
- The Steam workshop upload gate could fail with `fatal: bad object <before_sha>` or silently skip uploads when `github.event.before` refers to a commit not present in a shallow checkout or after history rewrites. 

### Description
- Update the workflow Checkout step to fetch full history by setting `fetch-depth: 0` so previous SHAs are more likely to be available. 
- Validate `github.event.before` exists as a commit using `git cat-file -e` before running `git diff`. 
- If the previous SHA is not available in the checkout, fall back to forcing the matrix target to upload and emit a clear diagnostic message. 

### Testing
- Executed the updated matrix gating logic locally with an unavailable `BEFORE_SHA` and confirmed the script prints a diagnostic and sets `should_upload=true` without producing a fatal git error. 
- Inspected the modified workflow file diff to verify the `fetch-depth` addition and the `git cat-file -e` / fallback changes were applied as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c42b56e6108323944e577f93c8233d)