### PR TITLE
Normalize IgnoredFactionTags and avoid re-adding defaults when world config exists

### DIFF
--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Config/ModConfig.Loading.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Config/ModConfig.Loading.cs
@@ -58,6 +58,7 @@ namespace ShipCoreFramework
             ResolveBlockGroupsForCores(ShipCores);
 
             ImportLegacyWorldSettingsIfNeeded(allowWorldStorageReadWrite, hasIgnoreAiSetting, hasIgnoredFactionTagsSetting, hasSelectedNoCoreSetting);
+            NormalizeIgnoredFactionTags(hasIgnoredFactionTagsSetting);
             EnsurePersistedWorldSettings();
             ResolveSelectedNoCore();
             NormalizeShipCoreBlockLimits(SelectedNoCore, "WorldStorage", SelectedNoCoreUniqueName);
@@ -67,7 +68,7 @@ namespace ShipCoreFramework
         internal void EnsurePersistedWorldSettings()
         {
             if (IgnoredFactionTags == null)
-                IgnoredFactionTags = new List<string>(DefaultIgnoredFactionTagValues);
+                IgnoredFactionTags = new List<string>();
 
             if (SelectedNoCoreUniqueName == null)
                 SelectedNoCoreUniqueName = string.Empty;
@@ -120,6 +121,21 @@ namespace ShipCoreFramework
                 if (Utils.TryLoadFromSandbox(LegacySelectedNoCoreKey, out legacySelectedNoCore) && legacySelectedNoCore != null)
                     SelectedNoCoreUniqueName = legacySelectedNoCore.UniqueName ?? string.Empty;
             }
+        }
+
+        private void NormalizeIgnoredFactionTags(bool hasIgnoredFactionTagsSetting)
+        {
+            if (IgnoredFactionTags == null)
+                IgnoredFactionTags = new List<string>();
+
+            IgnoredFactionTags = IgnoredFactionTags
+                .Where(tag => !string.IsNullOrWhiteSpace(tag))
+                .Select(tag => tag.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            if (!hasIgnoredFactionTagsSetting && IgnoredFactionTags.Count == 0)
+                IgnoredFactionTags = new List<string>(DefaultIgnoredFactionTagValues);
         }
 
         private void LoadBlockGroupsFromMod(MyObjectBuilder_Checkpoint.ModItem mod)

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Config/ModConfig.XmlModels.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Config/ModConfig.XmlModels.cs
@@ -29,7 +29,7 @@ namespace ShipCoreFramework
 
         [XmlArray("IgnoredFactionTags")]
         [XmlArrayItem("Tag")]
-        public List<string> IgnoredFactionTags = new List<string>(DefaultIgnoredFactionTagValues);
+        public List<string> IgnoredFactionTags = new List<string>();
 
         [XmlElement("SelectedNoCoreUniqueName")]
         public string SelectedNoCoreUniqueName = string.Empty;


### PR DESCRIPTION
### Motivation
- Prevent default ignored faction tags from being re-appended to an existing world-config list and ensure newly added tags are unique and normalized.

### Description
- Stop pre-populating `IgnoredFactionTags` in the XML model by changing the field default to an empty list (`ModConfig.XmlModels.cs`).
- Add `NormalizeIgnoredFactionTags(bool hasIgnoredFactionTagsSetting)` to trim entries, remove blanks, and deduplicate tags case-insensitively and call it after legacy/world imports (`ModConfig.Loading.cs`).
- Only seed the default ignored tag values when the world config did not include `<IgnoredFactionTags>` and the resulting list is empty, and stop injecting defaults in `EnsurePersistedWorldSettings` when the list is missing (`ModConfig.Loading.cs`).

### Testing
- Attempted to build with `dotnet build ShipCoreSystem.sln`, but the command failed in this environment because `dotnet` is not installed, so no build verification was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcbae425ac8323b12ef66d917c7605)