### PR TITLE
Restore upgrade module output extension from .sbc to .xml

### DIFF
--- a/docs/configurator/app.js
+++ b/docs/configurator/app.js
@@ -1431,7 +1431,7 @@ function generateXml(options = {}) {
   const coreFilenames = getUniqueCoreFilenames(state.shipCores);
   const upgradeModuleFilenames = state.upgradeModules.map((module, moduleIndex) => {
     const rawName = sanitizeFilenamePart(module.subtypeId) || sanitizeFilenamePart(module.uniqueName) || `Upgrade_Module_${moduleIndex + 1}`;
-    return `${rawName}.sbc`;
+    return `${rawName}.xml`;
   });
 
   const manifest = `${header}


### PR DESCRIPTION
### Motivation
- Upgrade module outputs were being generated with a `.sbc` extension causing uploaded/saved upgrade modules to be saved as SBCs instead of XMLs, so the configurator needs to produce XML files again for correct downstream handling and manifest references.

### Description
- Changed the generated upgrade module filename suffix from `.sbc` to `.xml` in `docs/configurator/app.js` within `generateXml()` by updating the `upgradeModuleFilenames` mapping.
- This update also causes the generated manifest entries (`<UpgradeModuleFilenames>`) to reference the `.xml` filenames instead of `.sbc`.

### Testing
- Verified the change by inspecting the diff with `git diff -- docs/configurator/app.js` and viewing the updated lines with `nl -ba docs/configurator/app.js | sed -n '1426,1438p'`, both showing the extension now set to `.xml` (success).
- Confirmed the file was committed with `git commit` and the repository status showed the single intended change (success).
- No automated test suite was executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8dd29c30c8323b1fb1fe0d1616c5b)