### PR TITLE
Add MaxPerFaction input to configurator core limits editor

### DIFF
--- a/docs/configurator/app.js
+++ b/docs/configurator/app.js
@@ -715,6 +715,7 @@ function renderShipCores() {
       <div class="row wrap">
         <label class="inline">MaxBackupCores <input data-action="core-maxbackupcores" data-c="${coreIndex}" class="small" type="number" value="${core.maxBackupCores}" /></label>
         <label class="inline">MaxPerPlayer <input data-action="core-maxpp" data-c="${coreIndex}" class="small" type="number" value="${core.maxPerPlayer}" /></label>
+        <label class="inline">MaxPerFaction <input data-action="core-maxpf" data-c="${coreIndex}" class="small" type="number" value="${core.maxPerFaction}" /></label>
         <label class="inline">MinPlayers <input data-action="core-minplayers" data-c="${coreIndex}" class="small" type="number" value="${core.minPerFaction}" /></label>
         <label class="inline">MaxPlayers <input data-action="core-maxplayers" data-c="${coreIndex}" class="small" type="number" value="${core.maxPlayers}" /></label>
       </div>


### PR DESCRIPTION
### Motivation
- Expose `MaxPerFaction` in the XML configurator UI so per-faction core limits can be viewed and edited in the in-browser editor.

### Description
- Added a `MaxPerFaction` numeric input to the core limits row in `docs/configurator/app.js` with `data-action="core-maxpf"` and the value bound to `core.maxPerFaction`, reusing the existing action/handler and export flow.

### Testing
- Ran `node --check docs/configurator/app.js` to validate the JavaScript and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e92f727f8c8323a567e2a3002f89e7)