### PR TITLE
Fix XML configurator binding after ModConfig file rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This mod serves as an alternative to the standard block limit system in Space En
 A static configurator lives under `docs/configurator` and is deployable through GitHub Pages.
 
 ### What it does
-- Always loads the bundled latest `ModConfig.cs` snapshot shipped with this repository.
+- Always loads the bundled latest `ModConfig.XmlModels.cs` snapshot shipped with this repository.
 - Lets you build reusable `BlockGroup` definitions once and reference them from multiple core `BlockLimits`.
 - Supports renovating existing XML by uploading prior:
   - `ShipCoreConfig_Groups.xml`

--- a/docs/configurator/app.js
+++ b/docs/configurator/app.js
@@ -2320,11 +2320,11 @@ ids("loadUploadedXml").addEventListener("click", async () => {
 });
 
 (async () => {
-  const response = await fetch("./assets/ModConfig.cs", { cache: "no-cache" });
+  const response = await fetch("./assets/ModConfig.XmlModels.cs", { cache: "no-cache" });
   const text = await response.text();
   state.schema = parseModConfigCs(text);
   ids("schemaPreview").textContent = JSON.stringify(state.schema, null, 2);
-  ids("parserStatus").textContent = `Loaded bundled ModConfig.cs and parsed ${Object.keys(state.schema).length} XML classes.`;
+  ids("parserStatus").textContent = `Loaded bundled ModConfig.XmlModels.cs and parsed ${Object.keys(state.schema).length} XML classes.`;
 
   if (restoreDraftFromStorage()) {
     renderBlockGroups();

--- a/docs/configurator/index.html
+++ b/docs/configurator/index.html
@@ -9,14 +9,14 @@
 <body>
   <header>
     <h1>SE Ship Core XML Configurator</h1>
-    <p>Uses the bundled latest <code>ModConfig.cs</code>, supports reusable block groups, and renovates existing XML files.</p>
+    <p>Uses the bundled latest <code>ModConfig.XmlModels.cs</code>, supports reusable block groups, and renovates existing XML files.</p>
   </header>
 
   <main>
     <section class="panel">
-      <h2>1) Bundled ModConfig.cs Schema</h2>
-      <p class="muted">The configurator always uses the bundled latest <code>ModConfig.cs</code> shipped with this tool.</p>
-      <div id="parserStatus" class="muted">Loading bundled ModConfig.cs…</div>
+      <h2>1) Bundled ModConfig.XmlModels.cs Schema</h2>
+      <p class="muted">The configurator always uses the bundled latest <code>ModConfig.XmlModels.cs</code> shipped with this tool.</p>
+      <div id="parserStatus" class="muted">Loading bundled ModConfig.XmlModels.cs…</div>
       <pre id="schemaPreview" class="code-block"></pre>
     </section>
 


### PR DESCRIPTION
### Motivation
- The bundled schema file was renamed from `ModConfig.cs` to `ModConfig.XmlModels.cs`, which broke the configurator's runtime loader and left UI text out of sync with the actual asset name.

### Description
- Updated the configurator runtime loader to fetch `./assets/ModConfig.XmlModels.cs` in `docs/configurator/app.js`.
- Updated the parser status message to reference `ModConfig.XmlModels.cs` in `docs/configurator/app.js`.
- Updated the configurator UI copy to consistently reference `ModConfig.XmlModels.cs` in `docs/configurator/index.html`.
- Updated the project README to mention `ModConfig.XmlModels.cs` instead of the old filename in `README.md`.

### Testing
- Ran `test -f docs/configurator/assets/ModConfig.XmlModels.cs` which returned success indicating the asset exists.
- Ran `rg -n "ModConfig\.XmlModels\.cs" docs/configurator/app.js docs/configurator/index.html README.md` which confirmed all updated files reference the new filename.
- Verified the modified files were staged and committed successfully (local commit completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e930eb1884832391efb2760526e9cf)