### PR TITLE
Add FactionPlayersNeededPerCore to XML model and web configurator

### DIFF
--- a/docs/configurator/app.js
+++ b/docs/configurator/app.js
@@ -350,6 +350,7 @@ function createDefaultCore() {
     maxPcu: -1,
     maxBackupCores: -1,
     maxPerFaction: -1,
+    factionPlayersNeededPerCore: -1,
     minPerFaction: -1,
     maxPlayers: -1,
     maxPerPlayer: -1,
@@ -716,6 +717,7 @@ function renderShipCores() {
         <label class="inline">MaxBackupCores <input data-action="core-maxbackupcores" data-c="${coreIndex}" class="small" type="number" value="${core.maxBackupCores}" /></label>
         <label class="inline">MaxPerPlayer <input data-action="core-maxpp" data-c="${coreIndex}" class="small" type="number" value="${core.maxPerPlayer}" /></label>
         <label class="inline">MaxPerFaction <input data-action="core-maxpf" data-c="${coreIndex}" class="small" type="number" value="${core.maxPerFaction}" /></label>
+        <label class="inline">FactionPlayersNeededPerCore <input data-action="core-faction-players-needed" data-c="${coreIndex}" class="small" type="number" value="${core.factionPlayersNeededPerCore}" /></label>
         <label class="inline">MinPlayers <input data-action="core-minplayers" data-c="${coreIndex}" class="small" type="number" value="${core.minPerFaction}" /></label>
         <label class="inline">MaxPlayers <input data-action="core-maxplayers" data-c="${coreIndex}" class="small" type="number" value="${core.maxPlayers}" /></label>
       </div>
@@ -921,6 +923,7 @@ function parseCoreXml(text, originalFileName = "") {
     maxPcu: numberOf(coreNode, "MaxPCU", -1),
     maxBackupCores: numberOf(coreNode, "MaxBackupCores", -1),
     maxPerFaction: numberOf(coreNode, "MaxPerFaction", -1),
+    factionPlayersNeededPerCore: numberOf(coreNode, "FactionPlayersNeededPerCore", -1),
     minPerFaction: numberOf(coreNode, "MinPlayers", numberOf(coreNode, "MinPerFaction", -1)),
     maxPlayers: numberOf(coreNode, "MaxPlayers", -1),
     maxPerPlayer: numberOf(coreNode, "MaxPerPlayer", -1),
@@ -1149,6 +1152,7 @@ function parseLegacyGridClass(gridClassNode, fallbackSubtype) {
     maxMass: numberOf(gridClassNode, "MaxMass", -1),
     maxPcu: numberOf(gridClassNode, "MaxPCU", -1),
     maxPerFaction: numberOf(gridClassNode, "MaxPerFaction", -1),
+    factionPlayersNeededPerCore: numberOf(gridClassNode, "FactionPlayersNeededPerCore", -1),
     minPerFaction: numberOf(gridClassNode, "MinPlayers", -1),
     maxPlayers: numberOf(gridClassNode, "MaxPlayers", -1),
     maxPerPlayer: numberOf(gridClassNode, "MaxPerPlayer", -1),
@@ -1418,7 +1422,7 @@ function generateXml(options = {}) {
   const header = '<?xml version="1.0" encoding="UTF-8"?>';
 
   const noCore = state.noCoreCore
-    ? `${header}\n<ShipCore>\n  <SubtypeId>${escapeXml(state.noCoreCore.subtypeId)}</SubtypeId>\n  <UniqueName>${escapeXml(state.noCoreCore.uniqueName)}</UniqueName>\n  <ForceBroadCast>${state.noCoreCore.forceBroadcast}</ForceBroadCast>\n  <ForceBroadCastRange>${state.noCoreCore.forceBroadcastRange}</ForceBroadCastRange>\n  <MobilityType>${escapeXml(state.noCoreCore.mobilityType)}</MobilityType>\n  <MaxBlocks>${state.noCoreCore.maxBlocks}</MaxBlocks>\n  <MinBlocks>${state.noCoreCore.minBlocks}</MinBlocks>\n  <MaxMass>${state.noCoreCore.maxMass}</MaxMass>\n  <MaxPCU>${state.noCoreCore.maxPcu}</MaxPCU>\n  <MaxBackupCores>${state.noCoreCore.maxBackupCores}</MaxBackupCores>\n  <MaxPerPlayer>${state.noCoreCore.maxPerPlayer}</MaxPerPlayer>\n  <MaxPerFaction>${state.noCoreCore.maxPerFaction}</MaxPerFaction>\n  <MinPlayers>${state.noCoreCore.minPerFaction}</MinPlayers>\n  <MaxPlayers>${state.noCoreCore.maxPlayers}</MaxPlayers>\n  <SpeedBoostEnabled>${state.noCoreCore.speedBoostEnabled}</SpeedBoostEnabled>\n  <SpeedLimitType>${escapeXml(state.noCoreCore.speedLimitType)}</SpeedLimitType>\n  <EnableActiveDefenseModifiers>${state.noCoreCore.enableActiveDefenseModifiers}</EnableActiveDefenseModifiers>\n${writeAllowedUpgradeModulesXml(state.noCoreCore.allowedUpgradeModules)}${state.noCoreCore.allowedUpgradeModules?.length ? "\n" : ""}${writeModifierXml("Modifiers", state.noCoreCore.modifiers, DEFAULT_GRID_MODIFIERS)}\n${writeModifierXml("SpeedModifiers", state.noCoreCore.speedModifiers, DEFAULT_SPEED_MODIFIERS)}\n${writeModifierXml("PassiveDefenseModifiers", state.noCoreCore.passiveDefenseModifiers, DEFAULT_DEFENSE_MODIFIERS)}\n${writeModifierXml("ActiveDefenseModifiers", state.noCoreCore.activeDefenseModifiers, DEFAULT_DEFENSE_MODIFIERS)}\n${state.noCoreCore.blockLimits
+    ? `${header}\n<ShipCore>\n  <SubtypeId>${escapeXml(state.noCoreCore.subtypeId)}</SubtypeId>\n  <UniqueName>${escapeXml(state.noCoreCore.uniqueName)}</UniqueName>\n  <ForceBroadCast>${state.noCoreCore.forceBroadcast}</ForceBroadCast>\n  <ForceBroadCastRange>${state.noCoreCore.forceBroadcastRange}</ForceBroadCastRange>\n  <MobilityType>${escapeXml(state.noCoreCore.mobilityType)}</MobilityType>\n  <MaxBlocks>${state.noCoreCore.maxBlocks}</MaxBlocks>\n  <MinBlocks>${state.noCoreCore.minBlocks}</MinBlocks>\n  <MaxMass>${state.noCoreCore.maxMass}</MaxMass>\n  <MaxPCU>${state.noCoreCore.maxPcu}</MaxPCU>\n  <MaxBackupCores>${state.noCoreCore.maxBackupCores}</MaxBackupCores>\n  <MaxPerPlayer>${state.noCoreCore.maxPerPlayer}</MaxPerPlayer>\n  <MaxPerFaction>${state.noCoreCore.maxPerFaction}</MaxPerFaction>\n  <FactionPlayersNeededPerCore>${state.noCoreCore.factionPlayersNeededPerCore}</FactionPlayersNeededPerCore>\n  <MinPlayers>${state.noCoreCore.minPerFaction}</MinPlayers>\n  <MaxPlayers>${state.noCoreCore.maxPlayers}</MaxPlayers>\n  <SpeedBoostEnabled>${state.noCoreCore.speedBoostEnabled}</SpeedBoostEnabled>\n  <SpeedLimitType>${escapeXml(state.noCoreCore.speedLimitType)}</SpeedLimitType>\n  <EnableActiveDefenseModifiers>${state.noCoreCore.enableActiveDefenseModifiers}</EnableActiveDefenseModifiers>\n${writeAllowedUpgradeModulesXml(state.noCoreCore.allowedUpgradeModules)}${state.noCoreCore.allowedUpgradeModules?.length ? "\n" : ""}${writeModifierXml("Modifiers", state.noCoreCore.modifiers, DEFAULT_GRID_MODIFIERS)}\n${writeModifierXml("SpeedModifiers", state.noCoreCore.speedModifiers, DEFAULT_SPEED_MODIFIERS)}\n${writeModifierXml("PassiveDefenseModifiers", state.noCoreCore.passiveDefenseModifiers, DEFAULT_DEFENSE_MODIFIERS)}\n${writeModifierXml("ActiveDefenseModifiers", state.noCoreCore.activeDefenseModifiers, DEFAULT_DEFENSE_MODIFIERS)}\n${state.noCoreCore.blockLimits
       .map((limit) => writeBlockLimitXml(limit))
       .join("\n")}\n</ShipCore>`
     : `${header}\n<ShipCore />`;
@@ -1450,7 +1454,7 @@ ${state.upgradeModules
   const cores = state.shipCores.map((core, coreIndex) => ({
     file: coreFilenames[coreIndex],
     outputPath: buildCoreOutputPath(core, coreFilenames[coreIndex]),
-    body: `${header}\n<ShipCore>\n  <SubtypeId>${escapeXml(core.subtypeId)}</SubtypeId>\n  <UniqueName>${escapeXml(core.uniqueName)}</UniqueName>\n  <ForceBroadCast>${core.forceBroadcast}</ForceBroadCast>\n  <ForceBroadCastRange>${core.forceBroadcastRange}</ForceBroadCastRange>\n  <MobilityType>${escapeXml(core.mobilityType)}</MobilityType>\n  <MaxBlocks>${core.maxBlocks}</MaxBlocks>\n  <MinBlocks>${core.minBlocks}</MinBlocks>\n  <MaxMass>${core.maxMass}</MaxMass>\n  <MaxPCU>${core.maxPcu}</MaxPCU>\n  <MaxBackupCores>${core.maxBackupCores}</MaxBackupCores>\n  <MaxPerPlayer>${core.maxPerPlayer}</MaxPerPlayer>\n  <MaxPerFaction>${core.maxPerFaction}</MaxPerFaction>\n  <MinPlayers>${core.minPerFaction}</MinPlayers>\n  <MaxPlayers>${core.maxPlayers}</MaxPlayers>\n  <SpeedBoostEnabled>${core.speedBoostEnabled}</SpeedBoostEnabled>\n  <SpeedLimitType>${escapeXml(core.speedLimitType)}</SpeedLimitType>\n  <EnableActiveDefenseModifiers>${core.enableActiveDefenseModifiers}</EnableActiveDefenseModifiers>\n${writeAllowedUpgradeModulesXml(core.allowedUpgradeModules)}${core.allowedUpgradeModules?.length ? "\n" : ""}${writeModifierXml("Modifiers", core.modifiers, DEFAULT_GRID_MODIFIERS)}\n${writeModifierXml("SpeedModifiers", core.speedModifiers, DEFAULT_SPEED_MODIFIERS)}\n${writeModifierXml("PassiveDefenseModifiers", core.passiveDefenseModifiers, DEFAULT_DEFENSE_MODIFIERS)}\n${writeModifierXml("ActiveDefenseModifiers", core.activeDefenseModifiers, DEFAULT_DEFENSE_MODIFIERS)}\n${core.blockLimits
+    body: `${header}\n<ShipCore>\n  <SubtypeId>${escapeXml(core.subtypeId)}</SubtypeId>\n  <UniqueName>${escapeXml(core.uniqueName)}</UniqueName>\n  <ForceBroadCast>${core.forceBroadcast}</ForceBroadCast>\n  <ForceBroadCastRange>${core.forceBroadcastRange}</ForceBroadCastRange>\n  <MobilityType>${escapeXml(core.mobilityType)}</MobilityType>\n  <MaxBlocks>${core.maxBlocks}</MaxBlocks>\n  <MinBlocks>${core.minBlocks}</MinBlocks>\n  <MaxMass>${core.maxMass}</MaxMass>\n  <MaxPCU>${core.maxPcu}</MaxPCU>\n  <MaxBackupCores>${core.maxBackupCores}</MaxBackupCores>\n  <MaxPerPlayer>${core.maxPerPlayer}</MaxPerPlayer>\n  <MaxPerFaction>${core.maxPerFaction}</MaxPerFaction>\n  <FactionPlayersNeededPerCore>${core.factionPlayersNeededPerCore}</FactionPlayersNeededPerCore>\n  <MinPlayers>${core.minPerFaction}</MinPlayers>\n  <MaxPlayers>${core.maxPlayers}</MaxPlayers>\n  <SpeedBoostEnabled>${core.speedBoostEnabled}</SpeedBoostEnabled>\n  <SpeedLimitType>${escapeXml(core.speedLimitType)}</SpeedLimitType>\n  <EnableActiveDefenseModifiers>${core.enableActiveDefenseModifiers}</EnableActiveDefenseModifiers>\n${writeAllowedUpgradeModulesXml(core.allowedUpgradeModules)}${core.allowedUpgradeModules?.length ? "\n" : ""}${writeModifierXml("Modifiers", core.modifiers, DEFAULT_GRID_MODIFIERS)}\n${writeModifierXml("SpeedModifiers", core.speedModifiers, DEFAULT_SPEED_MODIFIERS)}\n${writeModifierXml("PassiveDefenseModifiers", core.passiveDefenseModifiers, DEFAULT_DEFENSE_MODIFIERS)}\n${writeModifierXml("ActiveDefenseModifiers", core.activeDefenseModifiers, DEFAULT_DEFENSE_MODIFIERS)}\n${core.blockLimits
       .map((limit) => writeBlockLimitXml(limit))
       .join("\n")}\n</ShipCore>`
   }));
@@ -1670,6 +1674,7 @@ document.addEventListener("input", (event) => {
   if (action === "core-maxpcu") selectedCore.maxPcu = Number(target.value || -1);
   if (action === "core-maxbackupcores") selectedCore.maxBackupCores = Number(target.value || -1);
   if (action === "core-maxpf") selectedCore.maxPerFaction = Number(target.value || -1);
+  if (action === "core-faction-players-needed") selectedCore.factionPlayersNeededPerCore = Number(target.value || -1);
   if (action === "core-minpf") selectedCore.minPerFaction = Number(target.value || -1);
   if (action === "core-minplayers") selectedCore.minPerFaction = Number(target.value || -1);
   if (action === "core-maxplayers") selectedCore.maxPlayers = Number(target.value || -1);

--- a/docs/configurator/assets/ModConfig.XmlModels.cs
+++ b/docs/configurator/assets/ModConfig.XmlModels.cs
@@ -108,6 +108,9 @@ namespace ShipCoreFramework
         [XmlElement("MaxPerFaction")]
         public int MaxPerFaction = -1;
 
+        [XmlElement("FactionPlayersNeededPerCore")]
+        public int FactionPlayersNeededPerCore = -1;
+
         [XmlElement("MaxPerPlayer")]
         public int MaxPerPlayer = -1;
 


### PR DESCRIPTION
### Motivation
- The runtime `ShipCore` config gained a `FactionPlayersNeededPerCore` field and the static configurator must expose, parse, and emit the same value so generated XML and the docs-side model remain in sync.

### Description
- Add `FactionPlayersNeededPerCore` as an `XmlElement` on the configurator XML model in `docs/configurator/assets/ModConfig.XmlModels.cs` so the asset schema matches the runtime contract.
- Expose the field in the web configurator by adding a `factionPlayersNeededPerCore` default to `createDefaultCore()` and inserting a numeric input labeled `FactionPlayersNeededPerCore` into the core UI in `docs/configurator/app.js`.
- Wire parsing and generation by reading `FactionPlayersNeededPerCore` from imported core and legacy grid-class XML and including the tag when emitting NoCore and per-core XML outputs in `docs/configurator/app.js`.
- Hook the new input into the configurator event handling so changes update the in-memory core state and persist into generated XML in `docs/configurator/app.js`.

### Testing
- Verified the new field appears in the XML model file and in the web configurator source by searching for `FactionPlayersNeededPerCore` and `factionPlayersNeededPerCore` across the configurator files, which returned the expected locations.
- Inspected the generated diffs to confirm the UI, parsing, generation, and model additions are present in `docs/configurator/app.js` and `docs/configurator/assets/ModConfig.XmlModels.cs`.
- No automated unit/integration test suite was executed for the static configurator during this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec1745c0fc832398379f24b89bc07c)