### PR TITLE
Multithreading rewrite

### DIFF
--- a/ShipCoreFramework/ShipCoreFramework.csproj
+++ b/ShipCoreFramework/ShipCoreFramework.csproj
@@ -5,6 +5,7 @@
         <Nullable>disable</Nullable>
         <LangVersion>6</LangVersion>
         <PlatformTarget>x64</PlatformTarget>
+        <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     </PropertyGroup>
 
     <ItemGroup>

--- a/ShipCoreFramework/ShipCoreFramework.csproj
+++ b/ShipCoreFramework/ShipCoreFramework.csproj
@@ -8,6 +8,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Mal.Mdk2.ModAnalyzers" Version="2.1.15">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
       <PackageReference Include="Mal.Mdk2.References" Version="2.2.7">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/API/ModAPI.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/API/ModAPI.cs
@@ -551,16 +551,10 @@ namespace ShipCoreFramework
         /// </summary>
         public static SpeedModifiersData GetSpeedModifiers(long gridId)
         {
-            var grid = MyAPIGateway.Entities.GetEntityById(gridId) as MyCubeGrid;
-            if (grid == null) return ConvertToSpeedModifiersData(null);
-
             try
             {
-                var groupData = MyAPIGateway.GridGroups.GetGridGroup(GridLinkTypeEnum.Mechanical, grid);
-                if (groupData == null) return ConvertToSpeedModifiersData(null);
-
                 GroupComponent groupComponent;
-                if (!Session.GroupDict.TryGetValue(groupData, out groupComponent)) return ConvertToSpeedModifiersData(null);
+                if (!TryGetGroupComponent(gridId, out groupComponent)) return ConvertToSpeedModifiersData(null);
 
                 var core = groupComponent.ShipCore;
                 return ConvertToSpeedModifiersData(core?.SpeedModifiers);
@@ -592,7 +586,7 @@ namespace ShipCoreFramework
                 GroupComponent groupComponent;
                 if (!TryGetGroupComponent(gridId, out groupComponent)) return false;
 
-                groupComponent.FrictionEnforcementEnabled = enabled;
+                groupComponent.SetFrictionEnforcementEnabled(enabled);
                 return true;
             }
             catch (Exception ex)
@@ -610,7 +604,7 @@ namespace ShipCoreFramework
             try
             {
                 GroupComponent groupComponent;
-                return TryGetGroupComponent(gridId, out groupComponent) && groupComponent.FrictionEnforcementEnabled;
+                return TryGetGroupComponent(gridId, out groupComponent) && groupComponent.GetFrictionEnforcementEnabled();
             }
             catch (Exception ex)
             {
@@ -631,7 +625,7 @@ namespace ShipCoreFramework
                 GroupComponent groupComponent;
                 if (!TryGetGroupComponent(gridId, out groupComponent)) return false;
 
-                groupComponent.FrictionMaximumDecelerationOverride = deceleration;
+                groupComponent.SetFrictionMaximumDecelerationOverride(deceleration);
                 return true;
             }
             catch (Exception ex)
@@ -651,7 +645,7 @@ namespace ShipCoreFramework
                 GroupComponent groupComponent;
                 if (!TryGetGroupComponent(gridId, out groupComponent)) return false;
 
-                groupComponent.FrictionMaximumDecelerationOverride = -1f;
+                groupComponent.SetFrictionMaximumDecelerationOverride(-1f);
                 return true;
             }
             catch (Exception ex)
@@ -669,7 +663,7 @@ namespace ShipCoreFramework
             try
             {
                 GroupComponent groupComponent;
-                return TryGetGroupComponent(gridId, out groupComponent) ? groupComponent.FrictionMaximumDecelerationOverride : -1f;
+                return TryGetGroupComponent(gridId, out groupComponent) ? groupComponent.GetFrictionMaximumDecelerationOverride() : -1f;
             }
             catch (Exception ex)
             {
@@ -689,11 +683,11 @@ namespace ShipCoreFramework
 
             if (speedMetersPerSecond < 0f)
             {
-                groupComponent.MinimumFrictionSpeedAbsoluteOverride = -1f;
+                groupComponent.SetMinimumFrictionSpeedAbsoluteOverride(-1f);
                 return MyTuple.Create(true, string.Empty);
             }
 
-            groupComponent.MinimumFrictionSpeedAbsoluteOverride = speedMetersPerSecond;
+            groupComponent.SetMinimumFrictionSpeedAbsoluteOverride(speedMetersPerSecond);
             return MyTuple.Create(true, string.Empty);
         }
 
@@ -708,11 +702,11 @@ namespace ShipCoreFramework
 
             if (speedMetersPerSecond < 0f)
             {
-                groupComponent.MaximumFrictionSpeedAbsoluteOverride = -1f;
+                groupComponent.SetMaximumFrictionSpeedAbsoluteOverride(-1f);
                 return MyTuple.Create(true, string.Empty);
             }
 
-            groupComponent.MaximumFrictionSpeedAbsoluteOverride = speedMetersPerSecond;
+            groupComponent.SetMaximumFrictionSpeedAbsoluteOverride(speedMetersPerSecond);
             return MyTuple.Create(true, string.Empty);
         }
 
@@ -722,7 +716,7 @@ namespace ShipCoreFramework
                 return MyTuple.Create(-1f, "World config uses modifier-based friction speeds; use GetFrictionMinimumSpeedModifierForGroup.");
 
             GroupComponent groupComponent;
-            return !TryGetGroupComponent(gridId, out groupComponent) ? MyTuple.Create(-1f, "Could not resolve logical grid group for the provided grid.") : MyTuple.Create(groupComponent.MinimumFrictionSpeedAbsoluteOverride, string.Empty);
+            return !TryGetGroupComponent(gridId, out groupComponent) ? MyTuple.Create(-1f, "Could not resolve logical grid group for the provided grid.") : MyTuple.Create(groupComponent.GetMinimumFrictionSpeedAbsoluteOverride(), string.Empty);
         }
 
         public static MyTuple<float, string> GetFrictionMaximumSpeedAbsoluteForGroup(long gridId)
@@ -731,7 +725,7 @@ namespace ShipCoreFramework
                 return MyTuple.Create(-1f, "World config uses modifier-based friction speeds; use GetFrictionMaximumSpeedModifierForGroup.");
 
             GroupComponent groupComponent;
-            return !TryGetGroupComponent(gridId, out groupComponent) ? MyTuple.Create(-1f, "Could not resolve logical grid group for the provided grid.") : MyTuple.Create(groupComponent.MaximumFrictionSpeedAbsoluteOverride, string.Empty);
+            return !TryGetGroupComponent(gridId, out groupComponent) ? MyTuple.Create(-1f, "Could not resolve logical grid group for the provided grid.") : MyTuple.Create(groupComponent.GetMaximumFrictionSpeedAbsoluteOverride(), string.Empty);
         }
 
         public static MyTuple<bool, string> SetFrictionMinimumSpeedModifierForGroup(long gridId, float modifier)
@@ -745,11 +739,11 @@ namespace ShipCoreFramework
 
             if (modifier < 0f)
             {
-                groupComponent.MinimumFrictionSpeedModifierOverride = -1f;
+                groupComponent.SetMinimumFrictionSpeedModifierOverride(-1f);
                 return MyTuple.Create(true, string.Empty);
             }
 
-            groupComponent.MinimumFrictionSpeedModifierOverride = modifier;
+            groupComponent.SetMinimumFrictionSpeedModifierOverride(modifier);
             return MyTuple.Create(true, string.Empty);
         }
 
@@ -764,11 +758,11 @@ namespace ShipCoreFramework
 
             if (modifier < 0f)
             {
-                groupComponent.MaximumFrictionSpeedModifierOverride = -1f;
+                groupComponent.SetMaximumFrictionSpeedModifierOverride(-1f);
                 return MyTuple.Create(true, string.Empty);
             }
 
-            groupComponent.MaximumFrictionSpeedModifierOverride = modifier;
+            groupComponent.SetMaximumFrictionSpeedModifierOverride(modifier);
             return MyTuple.Create(true, string.Empty);
         }
 
@@ -778,7 +772,7 @@ namespace ShipCoreFramework
                 return MyTuple.Create(-1f, "World config uses absolute friction speeds; use GetFrictionMinimumSpeedAbsoluteForGroup.");
 
             GroupComponent groupComponent;
-            return !TryGetGroupComponent(gridId, out groupComponent) ? MyTuple.Create(-1f, "Could not resolve logical grid group for the provided grid.") : MyTuple.Create(groupComponent.MinimumFrictionSpeedModifierOverride, string.Empty);
+            return !TryGetGroupComponent(gridId, out groupComponent) ? MyTuple.Create(-1f, "Could not resolve logical grid group for the provided grid.") : MyTuple.Create(groupComponent.GetMinimumFrictionSpeedModifierOverride(), string.Empty);
         }
 
         public static MyTuple<float, string> GetFrictionMaximumSpeedModifierForGroup(long gridId)
@@ -787,7 +781,7 @@ namespace ShipCoreFramework
                 return MyTuple.Create(-1f, "World config uses absolute friction speeds; use GetFrictionMaximumSpeedAbsoluteForGroup.");
 
             GroupComponent groupComponent;
-            return !TryGetGroupComponent(gridId, out groupComponent) ? MyTuple.Create(-1f, "Could not resolve logical grid group for the provided grid.") : MyTuple.Create(groupComponent.MaximumFrictionSpeedModifierOverride, string.Empty);
+            return !TryGetGroupComponent(gridId, out groupComponent) ? MyTuple.Create(-1f, "Could not resolve logical grid group for the provided grid.") : MyTuple.Create(groupComponent.GetMaximumFrictionSpeedModifierOverride(), string.Empty);
         }
 
         public static bool IsGroupDeactivated(long gridId)
@@ -810,6 +804,12 @@ namespace ShipCoreFramework
 
             try
             {
+                if (Utils.TryFindByGridId(gridId, out groupComponent))
+                    return true;
+
+                if (!Session.IsGameThread)
+                    return false;
+
                 var grid = MyAPIGateway.Entities.GetEntityById(gridId) as MyCubeGrid;
                 var groupData = MyAPIGateway.GridGroups.GetGridGroup(GridLinkTypeEnum.Mechanical, grid);
                 return groupData != null && Session.GroupDict.TryGetValue(groupData, out groupComponent);
@@ -1532,19 +1532,16 @@ namespace ShipCoreFramework
 
         public static bool IsBoostActive(long gridId)
         {
-            var grid = MyAPIGateway.Entities.GetEntityById(gridId) as MyCubeGrid;
-            if (grid == null) return false;
-
             try
             {
-                var groupData = MyAPIGateway.GridGroups.GetGridGroup(GridLinkTypeEnum.Mechanical, grid);
-                if (groupData == null) return false;
-
                 GroupComponent groupComponent;
-                if (!Session.GroupDict.TryGetValue(groupData, out groupComponent)) return false;
+                if (!TryGetGroupComponent(gridId, out groupComponent)) return false;
 
                 SpeedEnforcement.RefreshSpeedState(groupComponent);
-                return groupComponent.EffectiveBoostEnabled;
+                lock (groupComponent.SpeedStateLock)
+                {
+                    return groupComponent.EffectiveBoostEnabled;
+                }
             }
             catch (Exception ex)
             {

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/BeaconComponent.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/BeaconComponent.cs
@@ -29,8 +29,23 @@ namespace ShipCoreFramework
             CaptureDefaults();
             BeaconBlock.IsWorkingChanged += OnModuleWorkingChanged;
             BeaconBlock.PropertiesChanged += OnPropertiesChanged;
-            SyncForceBroadcast();
-            _groupComponent.RefreshPunishmentState();
+            if (Session.IsGameThread)
+            {
+                SyncForceBroadcast();
+                _groupComponent.RefreshPunishmentState();
+            }
+            else
+            {
+                var beaconId = BeaconBlock.EntityId;
+                ThreadWork.Enqueue(ThreadWork.StateCategory, "beacon-sync:" + beaconId,
+                    "Initial beacon sync " + beaconId,
+                    delegate { return IsBeaconAvailable() && !Session.IsShuttingDown; },
+                    delegate
+                    {
+                        SyncForceBroadcast();
+                        _groupComponent.RefreshPunishmentState();
+                    });
+            }
             return true;
         }
 

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/CoreComponent.Events.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/CoreComponent.Events.cs
@@ -6,13 +6,39 @@ namespace ShipCoreFramework
 {
     internal partial class CoreComponent
     {
+        private void AttachBlockEvents()
+        {
+            if (CoreBlock == null || _eventsAttached) return;
+            if (!Session.IsGameThread)
+            {
+                var blockId = CoreBlock.EntityId;
+                ThreadWork.Enqueue(ThreadWork.StateCategory, "core-events:" + blockId,
+                    "Attach core events " + blockId,
+                    delegate
+                    {
+                        return CoreBlock != null &&
+                               !CoreBlock.MarkedForClose &&
+                               !CoreBlock.Closed &&
+                               !Session.IsShuttingDown;
+                    },
+                    AttachBlockEvents);
+                return;
+            }
+
+            CoreBlock.OnUpgradeValuesChanged += OnUpgradeValuesChanged;
+            CoreBlock.AppendingCustomInfo += AppendingCustomInfo;
+            CoreBlock.IsWorkingChanged += OnIsWorkingChanged;
+            _eventsAttached = true;
+        }
+
         private void DetachBlockEvents()
         {
-            if (CoreBlock == null) return;
+            if (CoreBlock == null || !_eventsAttached) return;
 
             CoreBlock.OnUpgradeValuesChanged -= OnUpgradeValuesChanged;
             CoreBlock.AppendingCustomInfo -= AppendingCustomInfo;
             CoreBlock.IsWorkingChanged -= OnIsWorkingChanged;
+            _eventsAttached = false;
         }
 
         internal void Clean()

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/CoreComponent.Init.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/CoreComponent.Init.cs
@@ -10,7 +10,6 @@ namespace ShipCoreFramework
         internal bool Init(IMyFunctionalBlock coreBlock, GridComponent gridComponent, GroupComponent groupComponent)
         {
             CoreBlock = coreBlock;
-            CoreBlock.AddUpgradeValue("ShipCoreLink", 0f);
             var isIgnoredNpcGrid = Session.Config.IgnoreAiFactions && CoreBlock.CubeGrid.IsNpcSpawnedGrid;
             var builder = ResolvePlacementOwnerIdentityId();
             if (builder == 0 && !isIgnoredNpcGrid)
@@ -108,9 +107,7 @@ namespace ShipCoreFramework
                 {
                     _groupComponent.ScheduleExternalLimitValidation();
                     Utils.Log($"Deferring core limit validation for {SubtypeId} on {CoreBlock.CubeGrid.CustomName} while Nexus sync is settling.", 1);
-                    CoreBlock.OnUpgradeValuesChanged += OnUpgradeValuesChanged;
-                    CoreBlock.AppendingCustomInfo += AppendingCustomInfo;
-                    CoreBlock.IsWorkingChanged += OnIsWorkingChanged;
+                    AttachBlockEvents();
                     _groupComponent.DefenseValuesChanged();
                     return true;
                 }
@@ -120,9 +117,7 @@ namespace ShipCoreFramework
                 return false;
             }
 
-            CoreBlock.OnUpgradeValuesChanged += OnUpgradeValuesChanged;
-            CoreBlock.AppendingCustomInfo += AppendingCustomInfo;
-            CoreBlock.IsWorkingChanged += OnIsWorkingChanged;
+            AttachBlockEvents();
             _groupComponent.DefenseValuesChanged();
             return true;
         }

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/CoreComponent.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/CoreComponent.cs
@@ -19,8 +19,28 @@ namespace ShipCoreFramework
                 if (_isMainCore == value) return;
                 _isMainCore = value;
 
-                SaveCoreState();
-                CoreBlock?.RefreshCustomInfo();
+                if (Session.IsGameThread)
+                {
+                    SaveCoreState();
+                    CoreBlock?.RefreshCustomInfo();
+                    return;
+                }
+
+                var blockId = CoreBlock == null ? 0 : CoreBlock.EntityId;
+                ThreadWork.Enqueue(ThreadWork.StateCategory, "core-state:" + blockId,
+                    "Persist core main state " + blockId,
+                    delegate
+                    {
+                        return CoreBlock != null &&
+                               !CoreBlock.MarkedForClose &&
+                               !CoreBlock.Closed &&
+                               !Session.IsShuttingDown;
+                    },
+                    delegate
+                    {
+                        SaveCoreState();
+                        CoreBlock.RefreshCustomInfo();
+                    });
             }
         }
     }

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/CoreComponent.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/CoreComponent.cs
@@ -6,6 +6,7 @@ namespace ShipCoreFramework
     {
         private GroupComponent _groupComponent;
         private bool _isMainCore;
+        private bool _eventsAttached;
 
         internal string SubtypeId;
         internal IMyFunctionalBlock CoreBlock;

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GridComponent.Attachments.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GridComponent.Attachments.cs
@@ -18,7 +18,8 @@ namespace ShipCoreFramework
 
             var beaconComponent = new BeaconComponent(groupComponent);
             if (!beaconComponent.Init(beaconBlock)) return;
-            BeaconDictionary.Add(beaconBlock, beaconComponent);
+            if (!BeaconDictionary.TryAdd(beaconBlock, beaconComponent))
+                beaconComponent.Clean();
         }
 
         private void UntrackBeacon(IMyFunctionalBlock coreBlock)
@@ -27,9 +28,7 @@ namespace ShipCoreFramework
             if (beaconBlock == null) return;
 
             BeaconComponent beaconComponent;
-            if (!BeaconDictionary.TryGetValue(beaconBlock, out beaconComponent)) return;
-
-            BeaconDictionary.Remove(beaconBlock);
+            if (!BeaconDictionary.TryRemove(beaconBlock, out beaconComponent)) return;
             beaconComponent.Clean();
         }
 
@@ -40,7 +39,8 @@ namespace ShipCoreFramework
 
             var upgradeModuleComponent = new UpgradeModuleComponent(groupComponent);
             if (!upgradeModuleComponent.Init(block)) return;
-            _upgradeModuleDictionary.Add(block, upgradeModuleComponent);
+            if (!_upgradeModuleDictionary.TryAdd(block, upgradeModuleComponent))
+                upgradeModuleComponent.Clean();
         }
 
         private bool UntrackUpgradeModule(IMyFunctionalBlock block)
@@ -48,9 +48,7 @@ namespace ShipCoreFramework
             if (block == null) return false;
 
             UpgradeModuleComponent moduleComponent;
-            if (!_upgradeModuleDictionary.TryGetValue(block, out moduleComponent)) return false;
-
-            _upgradeModuleDictionary.Remove(block);
+            if (!_upgradeModuleDictionary.TryRemove(block, out moduleComponent)) return false;
             moduleComponent.Clean();
             return true;
         }

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GridComponent.Blocks.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GridComponent.Blocks.cs
@@ -122,7 +122,7 @@ namespace ShipCoreFramework
 
             if (Utils.IsCoreBlock(functionalBlock) || isTrackedUpgradeModule)
                 groupComponent.OnUpgradeModulesChanged();
-            else
+            else if (!groupComponent.IsInitializingGrids)
                 groupComponent.ApplyModifiers(groupComponent.Modifiers);
         }
 

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GridComponent.Blocks.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GridComponent.Blocks.cs
@@ -60,7 +60,11 @@ namespace ShipCoreFramework
                 var success = newCore.Init(functionalBlock, this, groupComponent);
                 if (!success) return;
 
-                CoreDictionary.Add(block.FatBlock, newCore);
+                if (!CoreDictionary.TryAdd(block.FatBlock, newCore))
+                {
+                    newCore.Clean();
+                    return;
+                }
 
                 if (!TryApplyLimitsOnAdd(block, limitBasedPunish)) return;
 
@@ -134,9 +138,8 @@ namespace ShipCoreFramework
             var functionalBlock = block.FatBlock as IMyFunctionalBlock;
             CoreComponent value = null;
             var removedUpgradeModule = false;
-            if (functionalBlock != null && CoreDictionary.TryGetValue(functionalBlock, out value))
+            if (functionalBlock != null && CoreDictionary.TryRemove(functionalBlock, out value))
             {
-                CoreDictionary.Remove(functionalBlock);
                 value.CoreDestroyed();
             }
             else

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GridComponent.Cleanup.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GridComponent.Cleanup.cs
@@ -40,7 +40,7 @@ namespace ShipCoreFramework
 
             _trackedConnectorIds.Clear();
 
-            Limits.Clear();
+            PublishLimitsSnapshot(null);
             foreach (var beaconComponent in BeaconDictionary.Values) beaconComponent.Clean();
             BeaconDictionary.Clear();
             foreach (var moduleComponent in _upgradeModuleDictionary.Values) moduleComponent.Clean();

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GridComponent.Connectors.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GridComponent.Connectors.cs
@@ -7,7 +7,7 @@ namespace ShipCoreFramework
         private void TrackConnector(IMyShipConnector connector)
         {
             if (connector == null) return;
-            if (!_trackedConnectorIds.Add(connector.EntityId)) return;
+            if (!_trackedConnectorIds.TryAdd(connector.EntityId, 0)) return;
 
             connector.IsConnectedChanged += ConnectorOnConnectionChanged;
             connector.AttachFinished += ConnectorOnConnectionChanged;
@@ -17,7 +17,8 @@ namespace ShipCoreFramework
         private void UntrackConnector(IMyShipConnector connector)
         {
             if (connector == null) return;
-            if (!_trackedConnectorIds.Remove(connector.EntityId)) return;
+            byte discarded;
+            if (!_trackedConnectorIds.TryRemove(connector.EntityId, out discarded)) return;
 
             connector.IsConnectedChanged -= ConnectorOnConnectionChanged;
             connector.AttachFinished -= ConnectorOnConnectionChanged;

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GridComponent.Limits.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GridComponent.Limits.cs
@@ -43,12 +43,7 @@ namespace ShipCoreFramework
                     }
                 }
 
-                LimitBucket groupBucket;
-                if (!GroupComponent.Limits.TryGetValue(limit, out groupBucket))
-                {
-                    groupBucket = new LimitBucket(0d);
-                    GroupComponent.Limits[limit] = groupBucket;
-                }
+                var groupBucket = GroupComponent.Limits.GetOrAdd(limit, _ => new LimitBucket(0d));
 
                 double currentWeight;
                 lock (groupBucket.BucketLock)
@@ -75,12 +70,7 @@ namespace ShipCoreFramework
                     }
                 }
 
-                LimitBucket gridBucket;
-                if (!Limits.TryGetValue(limit, out gridBucket))
-                {
-                    gridBucket = new LimitBucket(0d);
-                    Limits[limit] = gridBucket;
-                }
+                var gridBucket = Limits.GetOrAdd(limit, _ => new LimitBucket(0d));
 
                 lock (gridBucket.BucketLock)
                 {
@@ -115,8 +105,7 @@ namespace ShipCoreFramework
             {
                 if (limit == null) continue;
 
-                var bucket = new LimitBucket(0d);
-                Limits[limit] = bucket;
+                var bucket = Limits.GetOrAdd(limit, _ => new LimitBucket(0d));
 
                 foreach (var block in blocksCopy)
                 {

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GridComponent.Limits.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GridComponent.Limits.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Linq;
 using VRage.Game.ModAPI;
 
@@ -88,12 +89,12 @@ namespace ShipCoreFramework
             return true;
         }
 
-        internal void RecalculateLimits(GroupComponent group)
+        internal ConcurrentDictionary<BlockLimit, LimitBucket> BuildLimitsSnapshot(GroupComponent group)
         {
-            Limits.Clear();
+            var result = new ConcurrentDictionary<BlockLimit, LimitBucket>();
 
             var blockLimits = group.ShipCore.BlockLimits;
-            if (blockLimits == null || blockLimits.Length == 0) return;
+            if (blockLimits == null || blockLimits.Length == 0) return result;
 
             List<IMySlimBlock> blocksCopy;
             lock (_blocksLock)
@@ -105,7 +106,7 @@ namespace ShipCoreFramework
             {
                 if (limit == null) continue;
 
-                var bucket = Limits.GetOrAdd(limit, _ => new LimitBucket(0d));
+                var bucket = result.GetOrAdd(limit, _ => new LimitBucket(0d));
 
                 foreach (var block in blocksCopy)
                 {
@@ -117,6 +118,8 @@ namespace ShipCoreFramework
                     bucket.Members.Add(block);
                 }
             }
+
+            return result;
         }
     }
 }

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GridComponent.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GridComponent.cs
@@ -13,7 +13,8 @@ namespace ShipCoreFramework
         private IMyGridGroupData _groupData;
         private readonly object _blocksLock = new object();
         private readonly List<IMySlimBlock> _blocks = new List<IMySlimBlock>();
-        internal readonly ConcurrentDictionary<BlockLimit, LimitBucket> Limits = new ConcurrentDictionary<BlockLimit, LimitBucket>();
+        private ConcurrentDictionary<BlockLimit, LimitBucket> _limits = new ConcurrentDictionary<BlockLimit, LimitBucket>();
+        internal ConcurrentDictionary<BlockLimit, LimitBucket> Limits { get { return _limits; } }
         internal int BlockCount
         {
             get
@@ -61,6 +62,12 @@ namespace ShipCoreFramework
 
             var otherBlocks = blocks.Where(block => !Utils.IsCoreBlock(block)).ToList();
             foreach (var otherBlock in otherBlocks) BlockAddedInternal(otherBlock);
+        }
+
+        internal void PublishLimitsSnapshot(ConcurrentDictionary<BlockLimit, LimitBucket> limits)
+        {
+            System.Threading.Interlocked.Exchange(ref _limits,
+                limits ?? new ConcurrentDictionary<BlockLimit, LimitBucket>());
         }
 
         private void GridMarkedForClose(IngameIMyEntity entity)

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GridComponent.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GridComponent.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Sandbox.Game.Entities;
@@ -12,7 +13,7 @@ namespace ShipCoreFramework
         private IMyGridGroupData _groupData;
         private readonly object _blocksLock = new object();
         private readonly List<IMySlimBlock> _blocks = new List<IMySlimBlock>();
-        internal readonly Dictionary<BlockLimit, LimitBucket> Limits = new Dictionary<BlockLimit, LimitBucket>();
+        internal readonly ConcurrentDictionary<BlockLimit, LimitBucket> Limits = new ConcurrentDictionary<BlockLimit, LimitBucket>();
         internal int BlockCount
         {
             get
@@ -22,16 +23,16 @@ namespace ShipCoreFramework
             }
         }
 
-        internal readonly Dictionary<IMyCubeBlock, CoreComponent> CoreDictionary =
-            new Dictionary<IMyCubeBlock, CoreComponent>();
+        internal readonly ConcurrentDictionary<IMyCubeBlock, CoreComponent> CoreDictionary =
+            new ConcurrentDictionary<IMyCubeBlock, CoreComponent>();
 
-        internal readonly Dictionary<IMyCubeBlock, BeaconComponent> BeaconDictionary =
-            new Dictionary<IMyCubeBlock, BeaconComponent>();
+        internal readonly ConcurrentDictionary<IMyCubeBlock, BeaconComponent> BeaconDictionary =
+            new ConcurrentDictionary<IMyCubeBlock, BeaconComponent>();
 
-        private readonly Dictionary<IMyCubeBlock, UpgradeModuleComponent> _upgradeModuleDictionary =
-            new Dictionary<IMyCubeBlock, UpgradeModuleComponent>();
+        private readonly ConcurrentDictionary<IMyCubeBlock, UpgradeModuleComponent> _upgradeModuleDictionary =
+            new ConcurrentDictionary<IMyCubeBlock, UpgradeModuleComponent>();
 
-        private readonly HashSet<long> _trackedConnectorIds = new HashSet<long>();
+        private readonly ConcurrentDictionary<long, byte> _trackedConnectorIds = new ConcurrentDictionary<long, byte>();
 
         private GroupComponent GroupComponent
         {

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Abilities.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Abilities.cs
@@ -249,7 +249,13 @@ namespace ShipCoreFramework
 
         private GridDefenseModifiers GetCurrentDefenseModifiers()
         {
-            return _activeDefenseEnabled ? GetActiveDefenseModifiers() : GetPassiveDefenseModifiers();
+            bool activeDefenseEnabled;
+            lock (_abilityStateLock)
+            {
+                activeDefenseEnabled = _activeDefenseEnabled;
+            }
+
+            return activeDefenseEnabled ? GetActiveDefenseModifiers() : GetPassiveDefenseModifiers();
         }
 
         internal void RefreshDefenseModifierCache()
@@ -263,7 +269,7 @@ namespace ShipCoreFramework
             }
 
             var modifiers = GetCurrentDefenseModifiers();
-            foreach (var kvp in GridDictionary) CubeGridModifiers.DefenseModifiers[kvp.Key.EntityId] = modifiers;
+            foreach (var kvp in GridDictionary) CubeGridModifiers.DefenseModifiers.Set(kvp.Key.EntityId, modifiers);
         }
 
         internal void RemoveDefenseModifierCache(long gridEntityId)
@@ -314,49 +320,106 @@ namespace ShipCoreFramework
 
         internal void RunBoostTimerTick()
         {
-            if (BoostEnabled)
+            var expired = false;
+            lock (SpeedStateLock)
             {
-                _boostDurationTimer -= 1f;
-                if (!(_boostDurationTimer <= 0f)) return;
-                BoostEnabled = false;
-                InvalidateSpeedStateCache();
-                _boostCooldownTimer = BoostCoolDown * 60f;
-                Utils.ShowNotification("Boost Disengaged! Cooldown started.");
+                if (BoostEnabled)
+                {
+                    _boostDurationTimer -= 1f;
+                    if (!(_boostDurationTimer <= 0f)) return;
 
-                PostBoostRampActive = true;
-                PostBoostRampCap = -1f;
+                    BoostEnabled = false;
+                    InvalidateSpeedStateCache();
+                    _boostCooldownTimer = BoostCoolDown * 60f;
 
-                if (MainCoreComponent?.GridComponent?.Grid != null)
-                    ModAPI.BroadcastBoostDeactivated(GetRepresentativeGridId());
+                    PostBoostRampActive = true;
+                    PostBoostRampCap = -1f;
+                    expired = true;
+                }
+                else if (_boostCooldownTimer > 0f)
+                {
+                    _boostCooldownTimer -= 1f;
+                    if (_boostCooldownTimer < 0f) _boostCooldownTimer = 0f;
+                }
             }
-            else if (_boostCooldownTimer > 0f)
-            {
-                _boostCooldownTimer -= 1f;
-                if (_boostCooldownTimer < 0f) _boostCooldownTimer = 0f;
-            }
+
+            if (expired)
+                QueueBoostDeactivatedSideEffects();
         }
 
         internal void RunActiveDefenseTimerTick()
         {
-            if (_activeDefenseEnabled)
+            var expired = false;
+            lock (_abilityStateLock)
             {
-                _activeDefenseDurationTimer -= 1f;
-                if (!(_activeDefenseDurationTimer <= 0f)) return;
-                _activeDefenseEnabled = false;
+                if (_activeDefenseEnabled)
+                {
+                    _activeDefenseDurationTimer -= 1f;
+                    if (!(_activeDefenseDurationTimer <= 0f)) return;
 
-                RefreshDefenseModifierCache();
+                    _activeDefenseEnabled = false;
 
-                _activeDefenseCooldownTimer = ActiveDefenseCoolDown * 60f;
-                Utils.ShowNotification("Active Defense Disengaged! Cooldown started.");
-
-                if (MainCoreComponent?.GridComponent?.Grid != null)
-                    ModAPI.BroadcastActiveDefenseDeactivated(GetRepresentativeGridId());
+                    _activeDefenseCooldownTimer = ActiveDefenseCoolDown * 60f;
+                    expired = true;
+                }
+                else if (_activeDefenseCooldownTimer > 0f)
+                {
+                    _activeDefenseCooldownTimer -= 1f;
+                    if (_activeDefenseCooldownTimer < 0f) _activeDefenseCooldownTimer = 0f;
+                }
             }
-            else if (_activeDefenseCooldownTimer > 0f)
+
+            if (!expired) return;
+            RefreshDefenseModifierCache();
+            QueueActiveDefenseDeactivatedSideEffects();
+        }
+
+        private void QueueBoostDeactivatedSideEffects()
+        {
+            if (Session.IsGameThread)
             {
-                _activeDefenseCooldownTimer -= 1f;
-                if (_activeDefenseCooldownTimer < 0f) _activeDefenseCooldownTimer = 0f;
+                RunBoostDeactivatedSideEffects();
+                return;
             }
+
+            var groupKey = GetThreadWorkKey();
+            ThreadWork.Enqueue(ThreadWork.StateCategory, "boost-deactivated:" + groupKey,
+                "Boost deactivated side effects for group " + groupKey,
+                delegate { return !_closing && !Session.IsShuttingDown; },
+                RunBoostDeactivatedSideEffects);
+        }
+
+        private void RunBoostDeactivatedSideEffects()
+        {
+            Utils.ShowNotification("Boost Disengaged! Cooldown started.");
+
+            var representativeGridId = GetRepresentativeGridId();
+            if (representativeGridId != 0)
+                ModAPI.BroadcastBoostDeactivated(representativeGridId);
+        }
+
+        private void QueueActiveDefenseDeactivatedSideEffects()
+        {
+            if (Session.IsGameThread)
+            {
+                RunActiveDefenseDeactivatedSideEffects();
+                return;
+            }
+
+            var groupKey = GetThreadWorkKey();
+            ThreadWork.Enqueue(ThreadWork.StateCategory, "active-defense-deactivated:" + groupKey,
+                "Active defense deactivated side effects for group " + groupKey,
+                delegate { return !_closing && !Session.IsShuttingDown; },
+                RunActiveDefenseDeactivatedSideEffects);
+        }
+
+        private void RunActiveDefenseDeactivatedSideEffects()
+        {
+            Utils.ShowNotification("Active Defense Disengaged! Cooldown started.");
+
+            var representativeGridId = GetRepresentativeGridId();
+            if (representativeGridId != 0)
+                ModAPI.BroadcastActiveDefenseDeactivated(representativeGridId);
         }
 
         internal void ActivateDefense()
@@ -367,20 +430,30 @@ namespace ShipCoreFramework
                 return;
             }
 
-            if (_activeDefenseEnabled)
+            string rejectedMessage = null;
+            lock (_abilityStateLock)
             {
-                Utils.ShowNotification("Active Defense Time Remaining:" + (_activeDefenseDurationTimer / 60f).ToString("0.0"));
-                return;
+                if (_activeDefenseEnabled)
+                {
+                    rejectedMessage = "Active Defense Time Remaining:" + (_activeDefenseDurationTimer / 60f).ToString("0.0");
+                }
+                else if (_activeDefenseCooldownTimer > 0f)
+                {
+                    rejectedMessage = "Active Defense is cooling down! Cooldown Time:" +
+                                      (_activeDefenseCooldownTimer / 60f).ToString("0.0");
+                }
+                else
+                {
+                    _activeDefenseDurationTimer = ActiveDefenseDuration * 60f;
+                    _activeDefenseEnabled = true;
+                }
             }
 
-            if (_activeDefenseCooldownTimer > 0f)
+            if (rejectedMessage != null)
             {
-                Utils.ShowNotification("Active Defense is cooling down! Cooldown Time:" + (_activeDefenseCooldownTimer / 60f).ToString("0.0"));
+                Utils.ShowNotification(rejectedMessage);
                 return;
             }
-
-            _activeDefenseDurationTimer = ActiveDefenseDuration * 60f;
-            _activeDefenseEnabled = true;
 
             RefreshDefenseModifierCache();
 
@@ -398,25 +471,35 @@ namespace ShipCoreFramework
                 return;
             }
 
-            if (BoostEnabled)
+            string rejectedMessage = null;
+            lock (SpeedStateLock)
             {
-                Utils.ShowNotification("Boost Time Remaining:" + (_boostDurationTimer / 60f).ToString("0.0"));
+                if (BoostEnabled)
+                {
+                    rejectedMessage = "Boost Time Remaining:" + (_boostDurationTimer / 60f).ToString("0.0");
+                }
+                else if (_boostCooldownTimer > 0f)
+                {
+                    rejectedMessage = "Boost is cooling down! Cooldown Time:" +
+                                      (_boostCooldownTimer / 60f).ToString("0.0");
+                }
+                else
+                {
+                    BoostEnabled = true;
+                    InvalidateSpeedStateCache();
+                    PostBoostRampActive = false;
+                    PostBoostRampCap = -1f;
+
+                    _boostDurationTimer = BoostDuration * 60f;
+                }
+            }
+
+            if (rejectedMessage != null)
+            {
+                Utils.ShowNotification(rejectedMessage);
                 return;
             }
 
-            if (_boostCooldownTimer > 0f)
-            {
-                Utils.ShowNotification(
-                    "Boost is cooling down! Cooldown Time:" + (_boostCooldownTimer / 60f).ToString("0.0"));
-                return;
-            }
-
-            BoostEnabled = true;
-            InvalidateSpeedStateCache();
-            PostBoostRampActive = false;
-            PostBoostRampCap = -1f;
-
-            _boostDurationTimer = BoostDuration * 60f;
             Utils.ShowNotification("Boost Engaged!");
 
             if (MainCoreComponent?.GridComponent?.Grid != null)

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Abilities.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Abilities.cs
@@ -20,12 +20,22 @@ namespace ShipCoreFramework
         internal void RefreshPunishmentState()
         {
             if (_closing || Session.IsShuttingDown || IsInitializingGrids) return;
+            if (!Session.IsGameThread)
+            {
+                var groupKey = GetThreadWorkKey();
+                ThreadWork.Enqueue(ThreadWork.StateCategory, "punishment-refresh:" + groupKey,
+                    "Punishment state refresh for group " + groupKey,
+                    delegate { return !_closing && !Session.IsShuttingDown; },
+                    RefreshPunishmentState);
+                return;
+            }
 
             var mainCoreChanged = EnsureWorkingMainCore();
             var previousPunishModifiers = PunishModifiers;
 
             RefreshLimitedBlockPunishmentState();
             RefreshPunishmentFlags();
+            RefreshModifierStateCache();
             if (mainCoreChanged || previousPunishModifiers != PunishModifiers) ApplyModifiers(Modifiers);
             RefreshDefenseModifierCache();
         }
@@ -302,6 +312,16 @@ namespace ShipCoreFramework
 
         internal void ApplyModifiers(GridModifiers modifiers)
         {
+            if (!Session.IsGameThread)
+            {
+                var groupKey = GetThreadWorkKey();
+                ThreadWork.Enqueue(ThreadWork.StateCategory, "apply-modifiers:" + groupKey,
+                    "Apply modifiers for group " + groupKey,
+                    delegate { return !_closing && !Session.IsShuttingDown; },
+                    delegate { ApplyModifiers(modifiers); });
+                return;
+            }
+
             foreach (var kvp in GridDictionary)
             {
                 var blocksCopy = kvp.Value.GetBlocksCopy();
@@ -508,6 +528,11 @@ namespace ShipCoreFramework
 
         internal GridDefenseModifiers GetActiveDefenseModifiers()
         {
+            return Session.IsGameThread ? ComputeActiveDefenseModifiers() : GetCachedActiveDefenseModifiers();
+        }
+
+        private GridDefenseModifiers ComputeActiveDefenseModifiers()
+        {
             var modifiers = CubeGridModifiers.GetEffectiveDefenseModifiers(ShipCore.ActiveDefenseModifiers,
                 GetEffectiveUpgradeModules(true).Select(module => module.GetConfig()),
                 DefenseModifierTarget.Active);
@@ -516,6 +541,11 @@ namespace ShipCoreFramework
         }
 
         internal GridDefenseModifiers GetPassiveDefenseModifiers()
+        {
+            return Session.IsGameThread ? ComputePassiveDefenseModifiers() : GetCachedPassiveDefenseModifiers();
+        }
+
+        private GridDefenseModifiers ComputePassiveDefenseModifiers()
         {
             var modifiers = CubeGridModifiers.GetEffectiveDefenseModifiers(ShipCore.PassiveDefenseModifiers,
                 GetEffectiveUpgradeModules(true).Select(module => module.GetConfig()),

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Connectors.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Connectors.cs
@@ -157,12 +157,7 @@ namespace ShipCoreFramework
                             var weight = limit.GetWeight(key);
                             if (weight <= 0d) continue;
 
-                            LimitBucket groupBucket;
-                            if (!Limits.TryGetValue(limit, out groupBucket))
-                            {
-                                groupBucket = new LimitBucket(0d);
-                                Limits[limit] = groupBucket;
-                            }
+                            var groupBucket = Limits.GetOrAdd(limit, _ => new LimitBucket(0d));
 
                             lock (groupBucket.BucketLock)
                             {

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Connectors.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Connectors.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Sandbox.ModAPI.Ingame;
@@ -18,6 +19,7 @@ namespace ShipCoreFramework
         internal void OnConnectorsChanged()
         {
             if (_closing) return;
+            IncrementLimitGeneration();
 
             RebuildConnectorPunishmentLinks();
             if (MainCoreComponent == null) return;
@@ -129,8 +131,14 @@ namespace ShipCoreFramework
 
         private void ApplyCrossConnectorPunishment()
         {
+            ApplyCrossConnectorPunishment(Limits);
+        }
+
+        private void ApplyCrossConnectorPunishment(ConcurrentDictionary<BlockLimit, LimitBucket> targetLimits)
+        {
             var connectedGroups = GetConnectedNoCoreGroupDataSnapshot();
             if (connectedGroups.Count == 0) return;
+            if (targetLimits == null) return;
 
             var blockLimits = ShipCore?.BlockLimits;
             if (blockLimits == null || blockLimits.Length == 0) return;
@@ -157,7 +165,7 @@ namespace ShipCoreFramework
                             var weight = limit.GetWeight(key);
                             if (weight <= 0d) continue;
 
-                            var groupBucket = Limits.GetOrAdd(limit, _ => new LimitBucket(0d));
+                            var groupBucket = targetLimits.GetOrAdd(limit, _ => new LimitBucket(0d));
 
                             lock (groupBucket.BucketLock)
                             {

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Deactivation.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Deactivation.cs
@@ -37,6 +37,15 @@ namespace ShipCoreFramework
         internal void Deactivate(string reason = null)
         {
             if (Deactivated) return;
+            if (!Session.IsGameThread)
+            {
+                var groupKey = GetThreadWorkKey();
+                ThreadWork.Enqueue(ThreadWork.StateCategory, "deactivate:" + groupKey,
+                    "Deactivate group " + groupKey,
+                    delegate { return !_closing && !Session.IsShuttingDown; },
+                    delegate { Deactivate(reason); });
+                return;
+            }
 
             Deactivated = true;
 

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Lifecycle.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Lifecycle.cs
@@ -87,6 +87,7 @@ namespace ShipCoreFramework
             }
 
             MainCoreComponent = coreComponent;
+            IncrementLimitGeneration();
             SyncBeaconComponents();
             InvalidateSpeedStateCache();
             Session.MarkPhysicalSpeedClusterSourceDirty(this);
@@ -139,6 +140,7 @@ namespace ShipCoreFramework
             ModAPI.BroadcastCoreDeactivated(GetRepresentativeGridId(), type, old.CoreBlock.CustomName);
 
             MainCoreComponent = null;
+            IncrementLimitGeneration();
             InvalidateSpeedStateCache();
             Session.MarkPhysicalSpeedClusterSourceDirty(this);
             SyncNoCoreLimitTracking();
@@ -190,6 +192,7 @@ namespace ShipCoreFramework
                     removedMain = MainCoreComponent;
 
                 AddGroupBlocksCount(-comp.BlockCount);
+                IncrementLimitGeneration();
                 comp.Clean();
                 GridComponent discarded;
                 GridDictionary.TryRemove(g, out discarded);
@@ -207,8 +210,8 @@ namespace ShipCoreFramework
             }
 
             RebuildConnectorPunishmentLinks();
-            RecalculateAllLimits();
             RefreshPunishmentState();
+            QueueRecalculateAllLimits(true, ShouldForceLimitedBlocksOff());
             Session.RefreshPhysicalGroupLinkagesForGrid(grid);
             Session.RefreshPhysicalGroupLinkagesForGrids(GridDictionary.Keys.Cast<IMyCubeGrid>());
             ModAPI.BroadcastGridRemovedFromGroup(grid.EntityId, GetRepresentativeGridId());
@@ -319,7 +322,8 @@ namespace ShipCoreFramework
             foreach (var kvp in GridDictionary) kvp.Value.Clean();
             ClearGridDictionary();
             System.Threading.Interlocked.Exchange(ref _groupBlocksCount, 0);
-            Limits.Clear();
+            PublishLimitsSnapshot(null);
+            IncrementLimitGeneration();
         }
 
         private void SyncNoCoreLimitTracking()

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Lifecycle.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Lifecycle.cs
@@ -57,7 +57,9 @@ namespace ShipCoreFramework
         private void InitializeGridComponent(MyCubeGrid grid, IMyGridGroupData groupData)
         {
             var gridComp = new GridComponent();
-            GridDictionary.Add(grid, gridComp);
+            if (!GridDictionary.TryAdd(grid, gridComp))
+                return;
+
             gridComp.Init(grid, groupData);
         }
 
@@ -177,10 +179,10 @@ namespace ShipCoreFramework
                 if (MainCoreComponent?.GridComponent.Grid.EntityId == g.EntityId)
                     removedMain = MainCoreComponent;
 
-                _groupBlocksCount -= comp.BlockCount;
-                if (_groupBlocksCount < 0) _groupBlocksCount = 0;
+                AddGroupBlocksCount(-comp.BlockCount);
                 comp.Clean();
-                GridDictionary.Remove(g);
+                GridComponent discarded;
+                GridDictionary.TryRemove(g, out discarded);
             }
 
             if (removedMain != null) MainCoreLeftGroup(removedMain);
@@ -306,7 +308,7 @@ namespace ShipCoreFramework
             ClearPhysicalLinkedGroups();
             foreach (var kvp in GridDictionary) kvp.Value.Clean();
             ClearGridDictionary();
-            _groupBlocksCount = 0;
+            System.Threading.Interlocked.Exchange(ref _groupBlocksCount, 0);
             Limits.Clear();
         }
 

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Lifecycle.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Lifecycle.cs
@@ -116,6 +116,16 @@ namespace ShipCoreFramework
         {
             var old = MainCoreComponent;
             if (old == null) return;
+            if (!Session.IsGameThread)
+            {
+                var groupKey = GetThreadWorkKey();
+                ThreadWork.Enqueue(ThreadWork.StateCategory, "reset-core:" + groupKey,
+                    "Reset core for group " + groupKey,
+                    delegate { return !_closing && !Session.IsShuttingDown; },
+                    ResetCore);
+                return;
+            }
+
             old.IsMainCore = false;
 
             var type = ShipCore.SubtypeId;

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Limits.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Limits.cs
@@ -117,7 +117,7 @@ namespace ShipCoreFramework
 
         internal void OnBlockAddedToGroup()
         {
-            _groupBlocksCount++;
+            AddGroupBlocksCount(1);
             InvalidateSpeedStateCache();
             Session.MarkPhysicalSpeedClusterSourceDirty(this);
 
@@ -131,8 +131,7 @@ namespace ShipCoreFramework
 
         internal void OnBlockRemovedFromGroup()
         {
-            if (_groupBlocksCount > 0)
-                _groupBlocksCount--;
+            AddGroupBlocksCount(-1);
 
             InvalidateSpeedStateCache();
             Session.MarkPhysicalSpeedClusterSourceDirty(this);
@@ -429,12 +428,7 @@ namespace ShipCoreFramework
                     var limit = gridLimitKv.Key;
                     var gridBucket = gridLimitKv.Value;
 
-                    LimitBucket groupBucket;
-                    if (!Limits.TryGetValue(limit, out groupBucket))
-                    {
-                        groupBucket = new LimitBucket(0d);
-                        Limits[limit] = groupBucket;
-                    }
+                    var groupBucket = Limits.GetOrAdd(limit, _ => new LimitBucket(0d));
 
                     lock (gridBucket.BucketLock)
                     {

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Limits.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Limits.cs
@@ -177,7 +177,18 @@ namespace ShipCoreFramework
                 return;
 
             _pendingLimitPunishmentValidationTick = 0;
-            RefreshGroupStateAndEnforce();
+            if (Session.IsGameThread)
+            {
+                RefreshGroupStateAndEnforce();
+                return;
+            }
+
+            var representativeGridId = GetRepresentativeGridId();
+            var groupKey = GetThreadWorkKey();
+            ThreadWork.Enqueue(ThreadWork.ValidationCategory, "limit-validation:" + groupKey,
+                "Delayed limit validation for group " + representativeGridId,
+                delegate { return !_closing && !Session.IsShuttingDown; },
+                delegate { RefreshGroupStateAndEnforce(); });
         }
 
         internal void RunExternalLimitValidationTick()
@@ -198,6 +209,24 @@ namespace ShipCoreFramework
             }
 
             _pendingExternalLimitValidationTick = 0;
+
+            if (Session.IsGameThread)
+            {
+                ExecuteExternalLimitValidation();
+                return;
+            }
+
+            var representativeGridId = GetRepresentativeGridId();
+            var groupKey = GetThreadWorkKey();
+            ThreadWork.Enqueue(ThreadWork.ValidationCategory, "external-limit-validation:" + groupKey,
+                "External limit validation for group " + representativeGridId,
+                delegate { return !_closing && !Session.IsShuttingDown; },
+                ExecuteExternalLimitValidation);
+        }
+
+        private void ExecuteExternalLimitValidation()
+        {
+            if (_closing || Session.IsShuttingDown) return;
 
             var mainCore = MainCoreComponent;
             if (mainCore?.CoreBlock?.SlimBlock == null) return;

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Limits.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Limits.cs
@@ -165,7 +165,7 @@ namespace ShipCoreFramework
             var wasPunishingLimitedBlocks = PunishLimitedBlocks;
             RefreshLimitedBlockPunishmentState();
             if (!wasPunishingLimitedBlocks && PunishLimitedBlocks)
-                EnforceGroupPunishment(true);
+                QueueEnforceGroupPunishment(true);
         }
 
         private void RunPendingLimitPunishmentValidationTick()
@@ -242,6 +242,21 @@ namespace ShipCoreFramework
 
             mainCore.CoreBlock.SlimBlock.RemoveAndRefund();
             ResetCore();
+        }
+
+        private void QueueEnforceGroupPunishment(bool forceShutOffPunishment = false)
+        {
+            if (Session.IsGameThread)
+            {
+                EnforceGroupPunishment(forceShutOffPunishment);
+                return;
+            }
+
+            var groupKey = GetThreadWorkKey();
+            ThreadWork.Enqueue(ThreadWork.ValidationCategory, "group-punishment:" + groupKey,
+                "Group punishment enforcement for group " + GetRepresentativeGridId(),
+                delegate { return !_closing && !Session.IsShuttingDown; },
+                delegate { EnforceGroupPunishment(forceShutOffPunishment); });
         }
 
         private void EnforceGroupPunishment(bool forceShutOffPunishment = false)

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Limits.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Limits.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Sandbox.ModAPI;
@@ -18,6 +19,19 @@ namespace ShipCoreFramework
             {
                 Block = block;
                 Harm = harm;
+            }
+        }
+
+        private sealed class GridLimitSnapshot
+        {
+            internal readonly GridComponent GridComponent;
+            internal readonly ConcurrentDictionary<BlockLimit, LimitBucket> Limits;
+
+            internal GridLimitSnapshot(GridComponent gridComponent,
+                ConcurrentDictionary<BlockLimit, LimitBucket> limits)
+            {
+                GridComponent = gridComponent;
+                Limits = limits;
             }
         }
 
@@ -117,6 +131,7 @@ namespace ShipCoreFramework
 
         internal void OnBlockAddedToGroup()
         {
+            IncrementLimitGeneration();
             AddGroupBlocksCount(1);
             InvalidateSpeedStateCache();
             Session.MarkPhysicalSpeedClusterSourceDirty(this);
@@ -131,6 +146,7 @@ namespace ShipCoreFramework
 
         internal void OnBlockRemovedFromGroup()
         {
+            IncrementLimitGeneration();
             AddGroupBlocksCount(-1);
 
             InvalidateSpeedStateCache();
@@ -252,18 +268,14 @@ namespace ShipCoreFramework
                 return;
             }
 
-            var groupKey = GetThreadWorkKey();
-            ThreadWork.Enqueue(ThreadWork.ValidationCategory, "group-punishment:" + groupKey,
-                "Group punishment enforcement for group " + GetRepresentativeGridId(),
-                delegate { return !_closing && !Session.IsShuttingDown; },
-                delegate { EnforceGroupPunishment(forceShutOffPunishment); });
+            EnforceGroupPunishment(forceShutOffPunishment);
         }
 
         private void EnforceGroupPunishment(bool forceShutOffPunishment = false)
         {
             if (IsIgnoredGroup()) return;
 
-            RefreshPunishmentFlags();
+            if (Session.IsGameThread) RefreshPunishmentFlags();
 
             var pendingPunishments = new List<PendingBlockPunishment>();
             foreach (var kv in Limits)
@@ -361,6 +373,16 @@ namespace ShipCoreFramework
         internal float GetEffectiveMaxCount(BlockLimit limit)
         {
             if (limit == null) return 0f;
+            if (Session.IsGameThread) return ComputeEffectiveMaxCount(limit);
+
+            var cached = _cachedEffectiveMaxCounts;
+            float maxCount;
+            return cached != null && cached.TryGetValue(limit, out maxCount) ? maxCount : limit.MaxCount;
+        }
+
+        private float ComputeEffectiveMaxCount(BlockLimit limit)
+        {
+            if (limit == null) return 0f;
 
             var maxCount = limit.MaxCount;
             foreach (var module in GetEffectiveUpgradeModules(true))
@@ -382,6 +404,11 @@ namespace ShipCoreFramework
 
         internal int GetEffectiveMaxBlocks()
         {
+            return Session.IsGameThread ? ComputeEffectiveMaxBlocks() : _cachedEffectiveMaxBlocks;
+        }
+
+        private int ComputeEffectiveMaxBlocks()
+        {
             var max = ShipCore.MaxBlocks;
             if (max <= 0) return max;
             foreach (var module in GetEffectiveUpgradeModules(true))
@@ -398,6 +425,11 @@ namespace ShipCoreFramework
         }
 
         internal float GetEffectiveMaxMass()
+        {
+            return Session.IsGameThread ? ComputeEffectiveMaxMass() : _cachedEffectiveMaxMass;
+        }
+
+        private float ComputeEffectiveMaxMass()
         {
             var max = ShipCore.MaxMass;
             if (max <= 0) return max;
@@ -416,6 +448,11 @@ namespace ShipCoreFramework
 
         internal int GetEffectiveMaxPCU()
         {
+            return Session.IsGameThread ? ComputeEffectiveMaxPCU() : _cachedEffectiveMaxPCU;
+        }
+
+        private int ComputeEffectiveMaxPCU()
+        {
             var max = ShipCore.MaxPCU;
             if (max <= 0) return max;
             foreach (var module in GetEffectiveUpgradeModules(true))
@@ -431,14 +468,48 @@ namespace ShipCoreFramework
             return max;
         }
 
-        private void RecalculateAllLimits()
+        private void RefreshEffectiveLimitCache()
         {
-            Limits.Clear();
+            _cachedEffectiveMaxBlocks = ComputeEffectiveMaxBlocks();
+            _cachedEffectiveMaxPCU = ComputeEffectiveMaxPCU();
+            _cachedEffectiveMaxMass = ComputeEffectiveMaxMass();
+
+            var effectiveMaxCounts = new Dictionary<BlockLimit, float>();
+            var blockLimits = ShipCore.BlockLimits;
+            if (blockLimits != null)
+            {
+                foreach (var limit in blockLimits)
+                    if (limit != null)
+                        effectiveMaxCounts[limit] = ComputeEffectiveMaxCount(limit);
+            }
+
+            _cachedEffectiveMaxCounts = effectiveMaxCounts;
+        }
+
+        private void QueueRecalculateAllLimits(bool enforceAfterPublish, bool forceShutOffPunishment)
+        {
+            var generation = GetLimitGeneration();
+            MyAPIGateway.Parallel.StartBackground(() =>
+            {
+                if (!BuildAndPublishLimitSnapshots(generation)) return;
+                if (enforceAfterPublish)
+                    EnforceGroupPunishment(forceShutOffPunishment);
+            });
+        }
+
+        private bool BuildAndPublishLimitSnapshots(int generation)
+        {
+            if (_closing || Session.IsShuttingDown) return false;
+
+            var groupLimits = new ConcurrentDictionary<BlockLimit, LimitBucket>();
+            var gridSnapshots = new List<GridLimitSnapshot>();
 
             foreach (var comp in GridDictionary.Values)
             {
-                comp.RecalculateLimits(this);
-                foreach (var gridLimitKv in comp.Limits)
+                var gridLimits = comp.BuildLimitsSnapshot(this);
+                gridSnapshots.Add(new GridLimitSnapshot(comp, gridLimits));
+
+                foreach (var gridLimitKv in gridLimits)
                 {
                     var limit = gridLimitKv.Key;
                     var gridBucket = gridLimitKv.Value;
@@ -456,9 +527,34 @@ namespace ShipCoreFramework
                 }
             }
 
-            ApplyCrossConnectorPunishment();
+            ApplyCrossConnectorPunishment(groupLimits);
 
-            if (MyGroup != null) ModAPI.BroadcastLimitsRecalculated(GetRepresentativeGridId());
+            lock (_limitSnapshotLock)
+            {
+                if (_closing || Session.IsShuttingDown || generation != GetLimitGeneration())
+                    return false;
+
+                foreach (var snapshot in gridSnapshots)
+                    if (snapshot.GridComponent != null)
+                        snapshot.GridComponent.PublishLimitsSnapshot(snapshot.Limits);
+
+                PublishLimitsSnapshot(groupLimits);
+            }
+
+            if (MyGroup != null)
+            {
+                var representativeGridId = GetRepresentativeGridId();
+                if (Session.IsGameThread)
+                    ModAPI.BroadcastLimitsRecalculated(representativeGridId);
+                else
+                    MyAPIGateway.Utilities.InvokeOnGameThread(() =>
+                    {
+                        if (!_closing && !Session.IsShuttingDown)
+                            ModAPI.BroadcastLimitsRecalculated(representativeGridId);
+                    });
+            }
+
+            return true;
         }
 
         internal static bool IsValidDirection(IMyCubeBlock myCore, IMySlimBlock block,

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Ownership.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Ownership.cs
@@ -96,6 +96,11 @@ namespace ShipCoreFramework
 
         internal bool IsIgnoredGroup()
         {
+            return Session.IsGameThread ? ComputeIsIgnoredGroup() : GetCachedIsIgnoredGroup();
+        }
+
+        private bool ComputeIsIgnoredGroup()
+        {
             if (IsIgnoredByAiOrFactionTag()) return true;
             if (OwnerId == 0) return true;
             var player = MyAPIGateway.Players.TryGetIdentityId(OwnerId);
@@ -118,6 +123,13 @@ namespace ShipCoreFramework
 
         internal long GetRepresentativeGridId()
         {
+            if (!Session.IsGameThread)
+                return GetCachedRepresentativeGridId();
+
+            RefreshGridStateCache();
+            var cachedRepresentativeGridId = GetCachedRepresentativeGridId();
+            if (cachedRepresentativeGridId != 0) return cachedRepresentativeGridId;
+
             var main = MainCoreComponent?.GridComponent?.Grid;
             var grid = main ?? GridDictionary.Keys.FirstOrDefault();
             return grid?.EntityId ?? 0;

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.SpeedState.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.SpeedState.cs
@@ -1,12 +1,10 @@
-using System.Threading;
-
 namespace ShipCoreFramework
 {
     internal partial class GroupComponent
     {
         internal void InvalidateSpeedStateCache()
         {
-            Volatile.Write(ref LastSpeedStateUpdateTick, -1);
+            LastSpeedStateUpdateTick = -1;
         }
 
         internal void SetFrictionEnforcementEnabled(bool enabled)

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.SpeedState.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.SpeedState.cs
@@ -1,10 +1,114 @@
+using System.Threading;
+
 namespace ShipCoreFramework
 {
     internal partial class GroupComponent
     {
         internal void InvalidateSpeedStateCache()
         {
-            LastSpeedStateUpdateTick = -1;
+            Volatile.Write(ref LastSpeedStateUpdateTick, -1);
+        }
+
+        internal void SetFrictionEnforcementEnabled(bool enabled)
+        {
+            lock (SpeedStateLock)
+            {
+                FrictionEnforcementEnabled = enabled;
+                InvalidateSpeedStateCache();
+            }
+        }
+
+        internal bool GetFrictionEnforcementEnabled()
+        {
+            lock (SpeedStateLock)
+            {
+                return FrictionEnforcementEnabled;
+            }
+        }
+
+        internal void SetFrictionMaximumDecelerationOverride(float value)
+        {
+            lock (SpeedStateLock)
+            {
+                FrictionMaximumDecelerationOverride = value;
+                InvalidateSpeedStateCache();
+            }
+        }
+
+        internal float GetFrictionMaximumDecelerationOverride()
+        {
+            lock (SpeedStateLock)
+            {
+                return FrictionMaximumDecelerationOverride;
+            }
+        }
+
+        internal void SetMinimumFrictionSpeedAbsoluteOverride(float value)
+        {
+            lock (SpeedStateLock)
+            {
+                MinimumFrictionSpeedAbsoluteOverride = value;
+                InvalidateSpeedStateCache();
+            }
+        }
+
+        internal float GetMinimumFrictionSpeedAbsoluteOverride()
+        {
+            lock (SpeedStateLock)
+            {
+                return MinimumFrictionSpeedAbsoluteOverride;
+            }
+        }
+
+        internal void SetMaximumFrictionSpeedAbsoluteOverride(float value)
+        {
+            lock (SpeedStateLock)
+            {
+                MaximumFrictionSpeedAbsoluteOverride = value;
+                InvalidateSpeedStateCache();
+            }
+        }
+
+        internal float GetMaximumFrictionSpeedAbsoluteOverride()
+        {
+            lock (SpeedStateLock)
+            {
+                return MaximumFrictionSpeedAbsoluteOverride;
+            }
+        }
+
+        internal void SetMinimumFrictionSpeedModifierOverride(float value)
+        {
+            lock (SpeedStateLock)
+            {
+                MinimumFrictionSpeedModifierOverride = value;
+                InvalidateSpeedStateCache();
+            }
+        }
+
+        internal float GetMinimumFrictionSpeedModifierOverride()
+        {
+            lock (SpeedStateLock)
+            {
+                return MinimumFrictionSpeedModifierOverride;
+            }
+        }
+
+        internal void SetMaximumFrictionSpeedModifierOverride(float value)
+        {
+            lock (SpeedStateLock)
+            {
+                MaximumFrictionSpeedModifierOverride = value;
+                InvalidateSpeedStateCache();
+            }
+        }
+
+        internal float GetMaximumFrictionSpeedModifierOverride()
+        {
+            lock (SpeedStateLock)
+            {
+                return MaximumFrictionSpeedModifierOverride;
+            }
         }
     }
 }

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Upgrades.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Upgrades.cs
@@ -67,6 +67,7 @@ namespace ShipCoreFramework
         internal void OnUpgradeModulesChanged()
         {
             if (_closing || _refreshingUpgradeModules || IsInitializingGrids) return;
+            IncrementLimitGeneration();
 
             if (!Session.IsGameThread)
             {
@@ -94,7 +95,6 @@ namespace ShipCoreFramework
         {
             RefreshUpgradeModules();
             RebuildConnectorPunishmentLinks();
-            RecalculateAllLimits();
             RefreshMinimumBlocksLimitedBlockGateState();
             RefreshLimitedBlockPunishmentState();
             RefreshPunishmentState();
@@ -104,11 +104,12 @@ namespace ShipCoreFramework
 
             if (IsLimitPunishmentDeferred())
             {
+                QueueRecalculateAllLimits(false, false);
                 ScheduleLimitPunishmentValidation(PostInitializationLimitValidationDelayTicks);
                 return;
             }
 
-            EnforceGroupPunishment(ShouldForceLimitedBlocksOff());
+            QueueRecalculateAllLimits(true, ShouldForceLimitedBlocksOff());
         }
 
         private void RefreshUpgradeModules()

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Upgrades.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Upgrades.cs
@@ -68,6 +68,16 @@ namespace ShipCoreFramework
         {
             if (_closing || _refreshingUpgradeModules || IsInitializingGrids) return;
 
+            if (!Session.IsGameThread)
+            {
+                var groupKey = GetThreadWorkKey();
+                ThreadWork.Enqueue(ThreadWork.StateCategory, "upgrade-refresh:" + groupKey,
+                    "Upgrade/module refresh for group " + GetRepresentativeGridId(),
+                    delegate { return !_closing && !Session.IsShuttingDown; },
+                    delegate { OnUpgradeModulesChanged(); });
+                return;
+            }
+
             InvalidateSpeedStateCache();
             _refreshingUpgradeModules = true;
             try

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Upgrades.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.Upgrades.cs
@@ -98,6 +98,7 @@ namespace ShipCoreFramework
             RefreshMinimumBlocksLimitedBlockGateState();
             RefreshLimitedBlockPunishmentState();
             RefreshPunishmentState();
+            RefreshModifierStateCache();
             ApplyModifiers(Modifiers);
             DefenseValuesChanged();
 

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Sandbox.ModAPI;
 using VRage.Game.ModAPI;
 using ModEntity = VRage.ModAPI.IMyEntity;
@@ -19,7 +21,7 @@ namespace ShipCoreFramework
         internal SpeedModifiers SpeedModifiers => CubeGridModifiers.GetActiveSpeedModifiers(this);
 
         internal IMyFaction OwningFaction => MyAPIGateway.Session.Factions.TryGetPlayerFaction(OwnerId);
-        internal int GroupBlocksCount => _groupBlocksCount;
+        internal int GroupBlocksCount => Volatile.Read(ref _groupBlocksCount);
         internal int GroupPCU => GridDictionary.Sum(g => g.Key.BlocksPCU);
         internal float GroupMass {
             get
@@ -47,8 +49,8 @@ namespace ShipCoreFramework
         internal IMyGridGroupData MyGroup;
         internal CoreComponent MainCoreComponent;
 
-        internal readonly Dictionary<BlockLimit, LimitBucket> Limits = new Dictionary<BlockLimit, LimitBucket>();
-        internal readonly Dictionary<MyCubeGrid, GridComponent> GridDictionary = new Dictionary<MyCubeGrid, GridComponent>();
+        internal readonly ConcurrentDictionary<BlockLimit, LimitBucket> Limits = new ConcurrentDictionary<BlockLimit, LimitBucket>();
+        internal readonly ConcurrentDictionary<MyCubeGrid, GridComponent> GridDictionary = new ConcurrentDictionary<MyCubeGrid, GridComponent>();
 
         internal Dictionary<IMyCubeBlock, CoreComponent> CoreDictionary =>
             Utils.Flatten(GridDictionary.Values, component => component.CoreDictionary);
@@ -63,6 +65,19 @@ namespace ShipCoreFramework
         private void ClearGridDictionary()
         {
             GridDictionary.Clear();
+        }
+
+        private void AddGroupBlocksCount(int delta)
+        {
+            int current;
+            int updated;
+            do
+            {
+                current = Volatile.Read(ref _groupBlocksCount);
+                updated = current + delta;
+                if (updated < 0) updated = 0;
+            }
+            while (Interlocked.CompareExchange(ref _groupBlocksCount, updated, current) != current);
         }
 
         private MyCubeGrid GetMobilityReferenceGrid()

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.cs
@@ -18,8 +18,8 @@ namespace ShipCoreFramework
         private const int PostInitializationLimitValidationDelayTicks = 0;
 
         internal ShipCore ShipCore => Session.Config.GetShipCoreByTypeId(MainCoreComponent?.SubtypeId ?? string.Empty);
-        internal GridModifiers Modifiers => CubeGridModifiers.GetActiveModifiers(this);
-        internal SpeedModifiers SpeedModifiers => CubeGridModifiers.GetActiveSpeedModifiers(this);
+        internal GridModifiers Modifiers => GetCachedActiveGridModifiers();
+        internal SpeedModifiers SpeedModifiers => GetCachedActiveSpeedModifiers();
 
         internal IMyFaction OwningFaction => MyAPIGateway.Session.Factions.TryGetPlayerFaction(OwnerId);
         internal int GroupBlocksCount => Interlocked.CompareExchange(ref _groupBlocksCount, 0, 0);
@@ -168,6 +168,10 @@ namespace ShipCoreFramework
         private long[] _cachedMechanicalGridIds = new long[0];
         private CachedGridState[] _cachedGridStates = new CachedGridState[0];
         private bool _cachedIsIgnoredGroup;
+        private GridModifiers _cachedActiveGridModifiers = new GridModifiers();
+        private SpeedModifiers _cachedActiveSpeedModifiers = new SpeedModifiers();
+        private GridDefenseModifiers _cachedPassiveDefenseModifiers = new GridDefenseModifiers();
+        private GridDefenseModifiers _cachedActiveDefenseModifiers = new GridDefenseModifiers();
 
         private bool _closing;
         private bool _refreshingUpgradeModules;
@@ -187,6 +191,7 @@ namespace ShipCoreFramework
             if (_closing || Session.IsShuttingDown) return;
             RefreshGridStateCache();
             RefreshMassCache();
+            RefreshModifierStateCache();
             _cachedIsIgnoredGroup = ComputeIsIgnoredGroup();
         }
 
@@ -213,6 +218,36 @@ namespace ShipCoreFramework
         internal bool GetCachedIsIgnoredGroup()
         {
             return _cachedIsIgnoredGroup;
+        }
+
+        internal GridModifiers GetCachedActiveGridModifiers()
+        {
+            return _cachedActiveGridModifiers ?? new GridModifiers();
+        }
+
+        internal SpeedModifiers GetCachedActiveSpeedModifiers()
+        {
+            return _cachedActiveSpeedModifiers ?? new SpeedModifiers();
+        }
+
+        internal GridDefenseModifiers GetCachedPassiveDefenseModifiers()
+        {
+            return _cachedPassiveDefenseModifiers ?? new GridDefenseModifiers();
+        }
+
+        internal GridDefenseModifiers GetCachedActiveDefenseModifiers()
+        {
+            return _cachedActiveDefenseModifiers ?? new GridDefenseModifiers();
+        }
+
+        internal void RefreshModifierStateCache()
+        {
+            if (!Session.IsGameThread || _closing || Session.IsShuttingDown) return;
+
+            _cachedActiveGridModifiers = CubeGridModifiers.GetActiveModifiers(this);
+            _cachedActiveSpeedModifiers = CubeGridModifiers.GetActiveSpeedModifiers(this);
+            _cachedPassiveDefenseModifiers = ComputePassiveDefenseModifiers();
+            _cachedActiveDefenseModifiers = ComputeActiveDefenseModifiers();
         }
 
         private void RefreshGridStateCache()

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.cs
@@ -24,48 +24,21 @@ namespace ShipCoreFramework
         internal float GroupMass {
             get
             {
-                var referenceGrid = GridDictionary.Keys.FirstOrDefault(grid =>
-                    grid != null &&
-                    !grid.MarkedForClose &&
-                    !grid.Closed &&
-                    (grid as ModEntity)?.Physics != null);
-                if (referenceGrid == null) return 0f;
+                if (!Session.IsGameThread)
+                    return _cachedConfiguredMass;
 
-                float dryMass;
-                float wetMass;
-                try
-                {
-                    referenceGrid.GetCurrentMass(out dryMass, out wetMass, GridLinkTypeEnum.Mechanical);
-                }
-                catch (NullReferenceException)
-                {
-                    return 0f;
-                }
-
-                return Session.Config.MassTypeMode == MassTypeMode.Dry ? dryMass : wetMass;
+                RefreshMassCache();
+                return _cachedConfiguredMass;
             }
         }
         internal float GroupDryMass {
             get
             {
-                var referenceGrid = GridDictionary.Keys.FirstOrDefault(grid =>
-                    grid != null &&
-                    !grid.MarkedForClose &&
-                    !grid.Closed &&
-                    (grid as ModEntity)?.Physics != null);
-                if (referenceGrid == null) return 0f;
+                if (!Session.IsGameThread)
+                    return _cachedDryMass;
 
-                float dryMass;
-                float wetMass;
-                try
-                {
-                    referenceGrid.GetCurrentMass(out dryMass, out wetMass, GridLinkTypeEnum.Mechanical);
-                }
-                catch (NullReferenceException)
-                {
-                    return 0f;
-                }
-                return dryMass;
+                RefreshMassCache();
+                return _cachedDryMass;
             }
         }
         private float BoostDuration => SpeedModifiers.BoostDuration;
@@ -102,6 +75,11 @@ namespace ShipCoreFramework
                 .OrderByDescending(grid => grid.BlocksCount)
                 .ThenBy(grid => grid.EntityId)
                 .FirstOrDefault();
+        }
+
+        internal string GetThreadWorkKey()
+        {
+            return MyGroup != null ? MyGroup.GetHashCode().ToString() : GetRepresentativeGridId().ToString();
         }
 
         internal bool PunishModifiers;
@@ -147,6 +125,9 @@ namespace ShipCoreFramework
         private int _pendingExternalLimitValidationTick;
         private int _deferLimitPunishmentUntilTick;
         private int _pendingLimitPunishmentValidationTick;
+        private float _cachedDryMass;
+        private float _cachedWetMass;
+        private float _cachedConfiguredMass;
 
         private bool _closing;
         private bool _refreshingUpgradeModules;
@@ -160,5 +141,43 @@ namespace ShipCoreFramework
         internal float ActiveDefenseDuration => ShipCore.ActiveDefenseModifiers.Duration;
         internal float ActiveDefenseCoolDown => ShipCore.ActiveDefenseModifiers.Cooldown;
         internal bool IsInitializingGrids => _gridInitializationDepth > 0;
+
+        internal void RefreshGameThreadStateCache()
+        {
+            if (_closing || Session.IsShuttingDown) return;
+            RefreshMassCache();
+        }
+
+        private void RefreshMassCache()
+        {
+            var referenceGrid = GridDictionary.Keys.FirstOrDefault(grid =>
+                grid != null &&
+                !grid.MarkedForClose &&
+                !grid.Closed &&
+                (grid as ModEntity)?.Physics != null);
+            if (referenceGrid == null)
+            {
+                _cachedDryMass = 0f;
+                _cachedWetMass = 0f;
+                _cachedConfiguredMass = 0f;
+                return;
+            }
+
+            float dryMass;
+            float wetMass;
+            try
+            {
+                referenceGrid.GetCurrentMass(out dryMass, out wetMass, GridLinkTypeEnum.Mechanical);
+            }
+            catch (NullReferenceException)
+            {
+                dryMass = 0f;
+                wetMass = 0f;
+            }
+
+            _cachedDryMass = dryMass;
+            _cachedWetMass = wetMass;
+            _cachedConfiguredMass = Session.Config.MassTypeMode == MassTypeMode.Dry ? dryMass : wetMass;
+        }
     }
 }

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using Sandbox.ModAPI;
 using VRage.Game.ModAPI;
+using VRageMath;
 using ModEntity = VRage.ModAPI.IMyEntity;
 using MyCubeGrid = Sandbox.Game.Entities.MyCubeGrid;
 
@@ -22,7 +23,16 @@ namespace ShipCoreFramework
 
         internal IMyFaction OwningFaction => MyAPIGateway.Session.Factions.TryGetPlayerFaction(OwnerId);
         internal int GroupBlocksCount => Volatile.Read(ref _groupBlocksCount);
-        internal int GroupPCU => GridDictionary.Sum(g => g.Key.BlocksPCU);
+        internal int GroupPCU {
+            get
+            {
+                if (!Session.IsGameThread)
+                    return Volatile.Read(ref _cachedGroupPCU);
+
+                RefreshGridStateCache();
+                return Volatile.Read(ref _cachedGroupPCU);
+            }
+        }
         internal float GroupMass {
             get
             {
@@ -48,6 +58,14 @@ namespace ShipCoreFramework
 
         internal IMyGridGroupData MyGroup;
         internal CoreComponent MainCoreComponent;
+
+        internal struct CachedGridState
+        {
+            internal long EntityId;
+            internal string CustomName;
+            internal Vector3D Position;
+            internal long FirstOwnerId;
+        }
 
         internal readonly ConcurrentDictionary<BlockLimit, LimitBucket> Limits = new ConcurrentDictionary<BlockLimit, LimitBucket>();
         internal readonly ConcurrentDictionary<MyCubeGrid, GridComponent> GridDictionary = new ConcurrentDictionary<MyCubeGrid, GridComponent>();
@@ -115,6 +133,7 @@ namespace ShipCoreFramework
         internal float PostBoostRampCap = -1f;
 
         private readonly object _connectedGroupsLock = new object();
+        private readonly object _abilityStateLock = new object();
         internal readonly object SpeedStateLock = new object();
         private IMyGridGroupData _trackedPhysicalGroup;
         private readonly HashSet<IMyGridGroupData> _connectedPhysicalGroups = new HashSet<IMyGridGroupData>();
@@ -143,6 +162,12 @@ namespace ShipCoreFramework
         private float _cachedDryMass;
         private float _cachedWetMass;
         private float _cachedConfiguredMass;
+        private int _cachedGroupPCU;
+        private long _cachedRepresentativeGridId;
+        private MyCubeGrid[] _cachedMovableGrids = new MyCubeGrid[0];
+        private long[] _cachedMechanicalGridIds = new long[0];
+        private CachedGridState[] _cachedGridStates = new CachedGridState[0];
+        private bool _cachedIsIgnoredGroup;
 
         private bool _closing;
         private bool _refreshingUpgradeModules;
@@ -160,7 +185,84 @@ namespace ShipCoreFramework
         internal void RefreshGameThreadStateCache()
         {
             if (_closing || Session.IsShuttingDown) return;
+            RefreshGridStateCache();
             RefreshMassCache();
+            Volatile.Write(ref _cachedIsIgnoredGroup, ComputeIsIgnoredGroup());
+        }
+
+        internal long GetCachedRepresentativeGridId()
+        {
+            return Volatile.Read(ref _cachedRepresentativeGridId);
+        }
+
+        internal long[] GetCachedMechanicalGridIds()
+        {
+            return Volatile.Read(ref _cachedMechanicalGridIds) ?? new long[0];
+        }
+
+        internal MyCubeGrid[] GetCachedMovableGrids()
+        {
+            return Volatile.Read(ref _cachedMovableGrids) ?? new MyCubeGrid[0];
+        }
+
+        internal CachedGridState[] GetCachedGridStates()
+        {
+            return Volatile.Read(ref _cachedGridStates) ?? new CachedGridState[0];
+        }
+
+        internal bool GetCachedIsIgnoredGroup()
+        {
+            return Volatile.Read(ref _cachedIsIgnoredGroup);
+        }
+
+        private void RefreshGridStateCache()
+        {
+            var groupPcu = 0;
+            var representativeGridId = 0L;
+            var representativeBlocks = -1;
+            var movableGrids = new List<MyCubeGrid>();
+            var mechanicalGridIds = new List<long>();
+            var gridStates = new List<CachedGridState>();
+
+            var mainGrid = MainCoreComponent?.GridComponent?.Grid;
+            if (mainGrid != null && !mainGrid.MarkedForClose && !mainGrid.Closed)
+                representativeGridId = mainGrid.EntityId;
+
+            foreach (var grid in GridDictionary.Keys)
+            {
+                if (grid == null || grid.MarkedForClose || grid.Closed) continue;
+
+                groupPcu += grid.BlocksPCU;
+                mechanicalGridIds.Add(grid.EntityId);
+                var apiGrid = (IMyCubeGrid)grid;
+                var entity = (ModEntity)grid;
+                gridStates.Add(new CachedGridState
+                {
+                    EntityId = grid.EntityId,
+                    CustomName = apiGrid.CustomName ?? string.Empty,
+                    Position = entity.GetPosition(),
+                    FirstOwnerId = grid.BigOwners == null || grid.BigOwners.Count == 0 ? 0 : grid.BigOwners[0]
+                });
+
+                if (!grid.IsStatic)
+                    movableGrids.Add(grid);
+
+                if (representativeGridId == 0)
+                {
+                    var blocks = grid.BlocksCount;
+                    if (blocks > representativeBlocks || blocks == representativeBlocks && grid.EntityId < representativeGridId)
+                    {
+                        representativeBlocks = blocks;
+                        representativeGridId = grid.EntityId;
+                    }
+                }
+            }
+
+            Volatile.Write(ref _cachedGroupPCU, groupPcu);
+            Volatile.Write(ref _cachedRepresentativeGridId, representativeGridId);
+            Volatile.Write(ref _cachedMovableGrids, movableGrids.ToArray());
+            Volatile.Write(ref _cachedMechanicalGridIds, mechanicalGridIds.ToArray());
+            Volatile.Write(ref _cachedGridStates, gridStates.ToArray());
         }
 
         private void RefreshMassCache()

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.cs
@@ -67,7 +67,8 @@ namespace ShipCoreFramework
             internal long FirstOwnerId;
         }
 
-        internal readonly ConcurrentDictionary<BlockLimit, LimitBucket> Limits = new ConcurrentDictionary<BlockLimit, LimitBucket>();
+        private ConcurrentDictionary<BlockLimit, LimitBucket> _limits = new ConcurrentDictionary<BlockLimit, LimitBucket>();
+        internal ConcurrentDictionary<BlockLimit, LimitBucket> Limits { get { return _limits; } }
         internal readonly ConcurrentDictionary<MyCubeGrid, GridComponent> GridDictionary = new ConcurrentDictionary<MyCubeGrid, GridComponent>();
 
         internal Dictionary<IMyCubeBlock, CoreComponent> CoreDictionary =>
@@ -134,6 +135,7 @@ namespace ShipCoreFramework
 
         private readonly object _connectedGroupsLock = new object();
         private readonly object _abilityStateLock = new object();
+        private readonly object _limitSnapshotLock = new object();
         internal readonly object SpeedStateLock = new object();
         private IMyGridGroupData _trackedPhysicalGroup;
         private readonly HashSet<IMyGridGroupData> _connectedPhysicalGroups = new HashSet<IMyGridGroupData>();
@@ -172,6 +174,10 @@ namespace ShipCoreFramework
         private SpeedModifiers _cachedActiveSpeedModifiers = new SpeedModifiers();
         private GridDefenseModifiers _cachedPassiveDefenseModifiers = new GridDefenseModifiers();
         private GridDefenseModifiers _cachedActiveDefenseModifiers = new GridDefenseModifiers();
+        private int _cachedEffectiveMaxBlocks = -1;
+        private int _cachedEffectiveMaxPCU = -1;
+        private float _cachedEffectiveMaxMass = -1f;
+        private Dictionary<BlockLimit, float> _cachedEffectiveMaxCounts = new Dictionary<BlockLimit, float>();
 
         private bool _closing;
         private bool _refreshingUpgradeModules;
@@ -180,6 +186,7 @@ namespace ShipCoreFramework
         private bool _wasIgnoredGroup;
         private bool _noCoreLimitsRegistered;
         private string _registeredNoCoreLimitSubtypeId = string.Empty;
+        private int _limitGeneration;
         internal int LastSpeedStateUpdateTick = -1;
 
         internal float ActiveDefenseDuration => ShipCore.ActiveDefenseModifiers.Duration;
@@ -248,6 +255,7 @@ namespace ShipCoreFramework
             _cachedActiveSpeedModifiers = CubeGridModifiers.GetActiveSpeedModifiers(this);
             _cachedPassiveDefenseModifiers = ComputePassiveDefenseModifiers();
             _cachedActiveDefenseModifiers = ComputeActiveDefenseModifiers();
+            RefreshEffectiveLimitCache();
         }
 
         private void RefreshGridStateCache()
@@ -298,6 +306,24 @@ namespace ShipCoreFramework
             _cachedMovableGrids = movableGrids.ToArray();
             _cachedMechanicalGridIds = mechanicalGridIds.ToArray();
             _cachedGridStates = gridStates.ToArray();
+        }
+
+        private int GetLimitGeneration()
+        {
+            return Interlocked.CompareExchange(ref _limitGeneration, 0, 0);
+        }
+
+        private void IncrementLimitGeneration()
+        {
+            lock (_limitSnapshotLock)
+            {
+                Interlocked.Increment(ref _limitGeneration);
+            }
+        }
+
+        private void PublishLimitsSnapshot(ConcurrentDictionary<BlockLimit, LimitBucket> limits)
+        {
+            Interlocked.Exchange(ref _limits, limits ?? new ConcurrentDictionary<BlockLimit, LimitBucket>());
         }
 
         private void RefreshMassCache()

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/GroupComponent.cs
@@ -22,15 +22,15 @@ namespace ShipCoreFramework
         internal SpeedModifiers SpeedModifiers => CubeGridModifiers.GetActiveSpeedModifiers(this);
 
         internal IMyFaction OwningFaction => MyAPIGateway.Session.Factions.TryGetPlayerFaction(OwnerId);
-        internal int GroupBlocksCount => Volatile.Read(ref _groupBlocksCount);
+        internal int GroupBlocksCount => Interlocked.CompareExchange(ref _groupBlocksCount, 0, 0);
         internal int GroupPCU {
             get
             {
                 if (!Session.IsGameThread)
-                    return Volatile.Read(ref _cachedGroupPCU);
+                    return Interlocked.CompareExchange(ref _cachedGroupPCU, 0, 0);
 
                 RefreshGridStateCache();
-                return Volatile.Read(ref _cachedGroupPCU);
+                return Interlocked.CompareExchange(ref _cachedGroupPCU, 0, 0);
             }
         }
         internal float GroupMass {
@@ -91,7 +91,7 @@ namespace ShipCoreFramework
             int updated;
             do
             {
-                current = Volatile.Read(ref _groupBlocksCount);
+                current = Interlocked.CompareExchange(ref _groupBlocksCount, 0, 0);
                 updated = current + delta;
                 if (updated < 0) updated = 0;
             }
@@ -187,32 +187,32 @@ namespace ShipCoreFramework
             if (_closing || Session.IsShuttingDown) return;
             RefreshGridStateCache();
             RefreshMassCache();
-            Volatile.Write(ref _cachedIsIgnoredGroup, ComputeIsIgnoredGroup());
+            _cachedIsIgnoredGroup = ComputeIsIgnoredGroup();
         }
 
         internal long GetCachedRepresentativeGridId()
         {
-            return Volatile.Read(ref _cachedRepresentativeGridId);
+            return Interlocked.CompareExchange(ref _cachedRepresentativeGridId, 0L, 0L);
         }
 
         internal long[] GetCachedMechanicalGridIds()
         {
-            return Volatile.Read(ref _cachedMechanicalGridIds) ?? new long[0];
+            return _cachedMechanicalGridIds ?? new long[0];
         }
 
         internal MyCubeGrid[] GetCachedMovableGrids()
         {
-            return Volatile.Read(ref _cachedMovableGrids) ?? new MyCubeGrid[0];
+            return _cachedMovableGrids ?? new MyCubeGrid[0];
         }
 
         internal CachedGridState[] GetCachedGridStates()
         {
-            return Volatile.Read(ref _cachedGridStates) ?? new CachedGridState[0];
+            return _cachedGridStates ?? new CachedGridState[0];
         }
 
         internal bool GetCachedIsIgnoredGroup()
         {
-            return Volatile.Read(ref _cachedIsIgnoredGroup);
+            return _cachedIsIgnoredGroup;
         }
 
         private void RefreshGridStateCache()
@@ -258,11 +258,11 @@ namespace ShipCoreFramework
                 }
             }
 
-            Volatile.Write(ref _cachedGroupPCU, groupPcu);
-            Volatile.Write(ref _cachedRepresentativeGridId, representativeGridId);
-            Volatile.Write(ref _cachedMovableGrids, movableGrids.ToArray());
-            Volatile.Write(ref _cachedMechanicalGridIds, mechanicalGridIds.ToArray());
-            Volatile.Write(ref _cachedGridStates, gridStates.ToArray());
+            Interlocked.Exchange(ref _cachedGroupPCU, groupPcu);
+            Interlocked.Exchange(ref _cachedRepresentativeGridId, representativeGridId);
+            _cachedMovableGrids = movableGrids.ToArray();
+            _cachedMechanicalGridIds = mechanicalGridIds.ToArray();
+            _cachedGridStates = gridStates.ToArray();
         }
 
         private void RefreshMassCache()

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/UpgradeModuleComponent.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Components/UpgradeModuleComponent.cs
@@ -24,7 +24,10 @@ namespace ShipCoreFramework
             if (ModuleBlock == null) return false;
 
             SubtypeId = ModuleBlock.BlockDefinition.SubtypeId;
-            RefreshParentCore();
+            if (Session.IsGameThread)
+                RefreshParentCore();
+            else
+                ParentCoreComponent = null;
 
             ModuleBlock.EnabledChanged += OnModuleStateChanged;
             ModuleBlock.IsWorkingChanged += OnModuleWorkingChanged;

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Helpers/CubeGridModifiers.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Helpers/CubeGridModifiers.cs
@@ -31,6 +31,22 @@ namespace ShipCoreFramework
         internal static void RegisterUpgradeModuleLink(IMyCubeBlock block)
         {
             if (block == null) return;
+            if (!Session.IsGameThread)
+            {
+                var blockId = block.EntityId;
+                ThreadWork.Enqueue(ThreadWork.StateCategory, "upgrade-link:" + blockId,
+                    "Register upgrade link " + blockId,
+                    delegate
+                    {
+                        return block != null &&
+                               !block.MarkedForClose &&
+                               !block.Closed &&
+                               !Session.IsShuttingDown;
+                    },
+                    delegate { RegisterUpgradeModuleLink(block); });
+                return;
+            }
+
             block.AddUpgradeValue(UpgradeModuleLinkType, 0f);
         }
 

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Helpers/CubeGridModifiers.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Helpers/CubeGridModifiers.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Sandbox.Definitions;
@@ -22,7 +21,8 @@ namespace ShipCoreFramework
 
     internal static class CubeGridModifiers
     {
-        internal static readonly ConcurrentDictionary<long, GridDefenseModifiers> DefenseModifiers = new ConcurrentDictionary<long, GridDefenseModifiers>();
+        internal static readonly GameThreadWriteDictionary<long, GridDefenseModifiers> DefenseModifiers =
+            new GameThreadWriteDictionary<long, GridDefenseModifiers>(null, ThreadWork.StateCategory, "defense-modifiers");
         private const string UpgradeModuleLinkType = "ShipCoreLink";
         private static readonly List<MyEntity> ExplosionEntities = new List<MyEntity>();
         private static readonly MyStringHash EnergyDamageType = MyStringHash.GetOrCompute("Energy");

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Helpers/NoFlyZoneEnforcement.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Helpers/NoFlyZoneEnforcement.cs
@@ -1,6 +1,5 @@
-﻿using System.Linq;
-using Sandbox.Game.Entities;
-using Sandbox.ModAPI;
+﻿using System.Collections.Generic;
+using System.Linq;
 using VRage.Game.ModAPI;
 using VRage.Utils;
 using VRageMath;
@@ -21,57 +20,123 @@ namespace ShipCoreFramework
                 return;
             }
 
-            foreach (var zone in Session.Config.NoFlyZones)
+            var zones = Session.Config.NoFlyZones.ToArray();
+            var shipCore = groupComponent.ShipCore;
+            var coreName = shipCore == null ? string.Empty : shipCore.UniqueName;
+            var gridStates = groupComponent.GetCachedGridStates();
+            if (gridStates.Length == 0) return;
+
+            foreach (var zone in zones)
             {
-                if (zone.AllowedCoresSubtype.Contains(groupComponent.ShipCore.UniqueName)) continue;
+                if (zone == null) continue;
+                if (zone.AllowedCoresSubtype != null && zone.AllowedCoresSubtype.Contains(coreName)) continue;
 
-                foreach (var kvp in groupComponent.GridDictionary)
+                foreach (var gridState in gridStates)
                 {
-                    IMyCubeGrid grid = kvp.Key;
-
-                    var distanceSq = Vector3D.DistanceSquared(zone.Position, grid.GetPosition());
+                    var distanceSq = Vector3D.DistanceSquared(zone.Position, gridState.Position);
                     if (!(distanceSq <= zone.Radius * zone.Radius))
                     {
-                        var humanReadableDistance = Vector3D.Distance(zone.Position, grid.GetPosition());
+                        var humanReadableDistance = Vector3D.Distance(zone.Position, gridState.Position);
                         if (humanReadableDistance < zone.Radius + 2000.0)
-                            Utils.ShowNotification($"{grid.CustomName} is {humanReadableDistance - zone.Radius:F0}m from a no fly zone", ((MyCubeGrid)grid).BigOwners.FirstOrDefault());
+                            Utils.ShowNotification($"{gridState.CustomName} is {humanReadableDistance - zone.Radius:F0}m from a no fly zone", gridState.FirstOwnerId);
 
                         continue;
                     }
 
                     if (!doPunish) continue;
-
-                    var blocksCopy = kvp.Value.GetBlocksCopy();
-                    foreach (var block in blocksCopy)
-                    {
-                        if (block?.CubeGrid == null) continue;
-                        var blockKey = GridComponent.KeyOf(block);
-
-                        if (zone.ForceOff)
-                        {
-                            MyAPIGateway.Utilities.InvokeOnGameThread(() => block.WhackABlock(PunishmentType.ShutOff, DamageTypeNoFlyZone));
-                        }
-                        else
-                        {
-                            var blockLimits = groupComponent.ShipCore.BlockLimits;
-                            if (blockLimits == null) continue;
-
-                            foreach (var limit in blockLimits)
-                            {
-                                if (limit?.BlockGroups == null) continue;
-
-                                var match = limit.BlockGroups
-                                    .SelectMany(g => g.BlockTypes)
-                                    .Any(b => b != null && b.Matches(blockKey));
-
-                                if (!match) continue;
-                                if (limit.PunishByNoFlyZone) MyAPIGateway.Utilities.InvokeOnGameThread(() => block.WhackABlock(limit.PunishmentType, DamageTypeNoFlyZone));
-                            }
-                        }
-                    }
-
-                    Utils.Log($"Action Taken against Grid{grid.CustomName} in NoFlyZone: {zone.Id}", 3);
+                    QueueNoFlyZonePunishment(groupComponent, zone, gridState.EntityId, gridState.CustomName);
                 }
+            }
+        }
+
+        private static void QueueNoFlyZonePunishment(GroupComponent groupComponent, Zones zone, long gridEntityId, string gridName)
+        {
+            if (groupComponent == null || zone == null || gridEntityId == 0) return;
+
+            var groupKey = groupComponent.GetThreadWorkKey();
+            ThreadWork.Enqueue(ThreadWork.StateCategory, "nfz:" + groupKey + ":" + zone.Id + ":" + gridEntityId,
+                "No-fly zone punishment for grid " + gridEntityId,
+                delegate { return !Session.IsShuttingDown; },
+                delegate { ApplyNoFlyZonePunishment(groupComponent, zone, gridEntityId, gridName); });
+        }
+
+        private static void ApplyNoFlyZonePunishment(GroupComponent groupComponent, Zones zone, long gridEntityId, string gridName)
+        {
+            if (groupComponent == null || zone == null || groupComponent.IsIgnoredGroup()) return;
+
+            GridComponent gridComponent = null;
+            IMyCubeGrid grid = null;
+            foreach (var kvp in groupComponent.GridDictionary)
+            {
+                if (kvp.Key == null || kvp.Key.EntityId != gridEntityId) continue;
+                if (kvp.Key.MarkedForClose || kvp.Key.Closed) return;
+                grid = kvp.Key;
+                gridComponent = kvp.Value;
+                break;
+            }
+
+            if (grid == null || gridComponent == null) return;
+            if (Vector3D.DistanceSquared(zone.Position, grid.GetPosition()) > zone.Radius * zone.Radius) return;
+
+            var blocksCopy = gridComponent.GetBlocksCopy();
+            var punishments = BuildPunishments(groupComponent, zone, blocksCopy);
+            foreach (var punishment in punishments)
+            {
+                if (punishment.Block == null || punishment.Block.IsMovedBySplit || punishment.Block.CubeGrid == null) continue;
+                if (punishment.Block.CubeGrid.MarkedForClose || punishment.Block.CubeGrid.Closed) continue;
+                punishment.Block.WhackABlock(punishment.Harm, DamageTypeNoFlyZone);
+            }
+
+            if (punishments.Count > 0)
+                Utils.Log($"Action Taken against Grid{gridName} in NoFlyZone: {zone.Id}", 3);
+        }
+
+        private static List<PendingNoFlyPunishment> BuildPunishments(GroupComponent groupComponent, Zones zone, List<IMySlimBlock> blocks)
+        {
+            var punishments = new List<PendingNoFlyPunishment>();
+            if (blocks == null || blocks.Count == 0) return punishments;
+
+            if (zone.ForceOff)
+            {
+                foreach (var block in blocks)
+                    if (block?.CubeGrid != null)
+                        punishments.Add(new PendingNoFlyPunishment(block, PunishmentType.ShutOff));
+                return punishments;
+            }
+
+            var blockLimits = groupComponent.ShipCore.BlockLimits;
+            if (blockLimits == null) return punishments;
+
+            foreach (var block in blocks)
+            {
+                if (block?.CubeGrid == null) continue;
+                var blockKey = GridComponent.KeyOf(block);
+
+                foreach (var limit in blockLimits)
+                {
+                    if (limit?.BlockGroups == null || !limit.PunishByNoFlyZone) continue;
+
+                    var match = limit.BlockGroups
+                        .SelectMany(g => g.BlockTypes)
+                        .Any(b => b != null && b.Matches(blockKey));
+
+                    if (match)
+                        punishments.Add(new PendingNoFlyPunishment(block, limit.PunishmentType));
+                }
+            }
+
+            return punishments;
+        }
+
+        private struct PendingNoFlyPunishment
+        {
+            internal readonly IMySlimBlock Block;
+            internal readonly PunishmentType Harm;
+
+            internal PendingNoFlyPunishment(IMySlimBlock block, PunishmentType harm)
+            {
+                Block = block;
+                Harm = harm;
             }
         }
     }

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Helpers/SpeedEnforcement.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Helpers/SpeedEnforcement.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 using Sandbox.Game.Entities;
 using Sandbox.ModAPI;
 using VRage.Game.Components;
@@ -133,23 +134,45 @@ namespace ShipCoreFramework
 
             var activeCore = sourceGroup.ShipCore;
             var speedModifiers = CubeGridModifiers.GetActiveSpeedModifiers(sourceGroup);
+            float baseSpeedLimit;
+            float effectiveSpeedLimit;
+            bool effectiveBoostEnabled;
+            bool frictionEnforcementEnabled;
+            float frictionMaximumDecelerationOverride;
+            float minimumFrictionSpeedAbsoluteOverride;
+            float maximumFrictionSpeedAbsoluteOverride;
+            float minimumFrictionSpeedModifierOverride;
+            float maximumFrictionSpeedModifierOverride;
+            lock (sourceGroup.SpeedStateLock)
+            {
+                baseSpeedLimit = sourceGroup.BaseSpeedLimitMetersPerSecond;
+                effectiveSpeedLimit = sourceGroup.EffectiveSpeedLimitMetersPerSecond;
+                effectiveBoostEnabled = sourceGroup.EffectiveBoostEnabled;
+                frictionEnforcementEnabled = sourceGroup.FrictionEnforcementEnabled;
+                frictionMaximumDecelerationOverride = sourceGroup.FrictionMaximumDecelerationOverride;
+                minimumFrictionSpeedAbsoluteOverride = sourceGroup.MinimumFrictionSpeedAbsoluteOverride;
+                maximumFrictionSpeedAbsoluteOverride = sourceGroup.MaximumFrictionSpeedAbsoluteOverride;
+                minimumFrictionSpeedModifierOverride = sourceGroup.MinimumFrictionSpeedModifierOverride;
+                maximumFrictionSpeedModifierOverride = sourceGroup.MaximumFrictionSpeedModifierOverride;
+            }
+
             var context = new SpeedLimitContext
             {
                 EvaluatedGroup = groupComponent,
                 SourceGroup = sourceGroup,
                 ActiveCore = activeCore,
                 TargetGrids = targetGrids,
-                BaseMaxSpeed = sourceGroup.BaseSpeedLimitMetersPerSecond,
+                BaseMaxSpeed = baseSpeedLimit,
                 BoostMaxSpeed = speedModifiers == null
-                    ? sourceGroup.BaseSpeedLimitMetersPerSecond
+                    ? baseSpeedLimit
                     : Session.Config.MaxPossibleSpeedMetersPerSecond * speedModifiers.MaxBoost,
-                EffectiveMaxSpeed = sourceGroup.EffectiveSpeedLimitMetersPerSecond,
-                BoostActive = sourceGroup.EffectiveBoostEnabled,
-                FrictionEnforcementEnabled = sourceGroup.FrictionEnforcementEnabled,
+                EffectiveMaxSpeed = effectiveSpeedLimit,
+                BoostActive = effectiveBoostEnabled,
+                FrictionEnforcementEnabled = frictionEnforcementEnabled,
                 MinimumFrictionSpeed = 0f,
-                MaximumFrictionSpeed = sourceGroup.EffectiveSpeedLimitMetersPerSecond,
-                MaximumFrictionDeceleration = sourceGroup.FrictionMaximumDecelerationOverride >= 0f
-                    ? sourceGroup.FrictionMaximumDecelerationOverride
+                MaximumFrictionSpeed = effectiveSpeedLimit,
+                MaximumFrictionDeceleration = frictionMaximumDecelerationOverride >= 0f
+                    ? frictionMaximumDecelerationOverride
                     : Math.Max(0f, speedModifiers?.MaximumFrictionDeceleration ?? 0f)
             };
 
@@ -161,22 +184,22 @@ namespace ShipCoreFramework
 
             if (Session.Config.FrictionSpeedValueMode == FrictionSpeedValueMode.Absolute)
             {
-                minFrictionSpeed = sourceGroup.MinimumFrictionSpeedAbsoluteOverride >= 0f
-                    ? sourceGroup.MinimumFrictionSpeedAbsoluteOverride
+                minFrictionSpeed = minimumFrictionSpeedAbsoluteOverride >= 0f
+                    ? minimumFrictionSpeedAbsoluteOverride
                     : speedModifiers.MinimumFrictionSpeedAbsolute;
 
-                configuredMaxFrictionSpeed = sourceGroup.MaximumFrictionSpeedAbsoluteOverride >= 0f
-                    ? sourceGroup.MaximumFrictionSpeedAbsoluteOverride
+                configuredMaxFrictionSpeed = maximumFrictionSpeedAbsoluteOverride >= 0f
+                    ? maximumFrictionSpeedAbsoluteOverride
                     : speedModifiers.MaximumFrictionSpeedAbsolute;
             }
             else
             {
-                var minMod = sourceGroup.MinimumFrictionSpeedModifierOverride >= 0f
-                    ? sourceGroup.MinimumFrictionSpeedModifierOverride
+                var minMod = minimumFrictionSpeedModifierOverride >= 0f
+                    ? minimumFrictionSpeedModifierOverride
                     : speedModifiers.MinimumFrictionSpeedModifier;
 
-                var maxMod = sourceGroup.MaximumFrictionSpeedModifierOverride >= 0f
-                    ? sourceGroup.MaximumFrictionSpeedModifierOverride
+                var maxMod = maximumFrictionSpeedModifierOverride >= 0f
+                    ? maximumFrictionSpeedModifierOverride
                     : speedModifiers.MaximumFrictionSpeedModifier;
 
                 minFrictionSpeed = Session.Config.MaxPossibleSpeedMetersPerSecond * minMod;
@@ -195,10 +218,13 @@ namespace ShipCoreFramework
 
         private static void ApplySpeedState(GroupComponent groupComponent, SpeedLimitContext context)
         {
-            groupComponent.BaseSpeedLimitMetersPerSecond = context.BaseMaxSpeed;
-            groupComponent.EffectiveSpeedLimitMetersPerSecond = context.EffectiveMaxSpeed;
-            groupComponent.EffectiveBoostEnabled = context.BoostActive;
-            groupComponent.SpeedSourceGroupGridId = GetSpeedSourceGridId(context.SourceGroup, groupComponent);
+            lock (groupComponent.SpeedStateLock)
+            {
+                groupComponent.BaseSpeedLimitMetersPerSecond = context.BaseMaxSpeed;
+                groupComponent.EffectiveSpeedLimitMetersPerSecond = context.EffectiveMaxSpeed;
+                groupComponent.EffectiveBoostEnabled = context.BoostActive;
+                groupComponent.SpeedSourceGroupGridId = GetSpeedSourceGridId(context.SourceGroup, groupComponent);
+            }
         }
 
         private static GroupComponent ResolveSpeedSourceGroup(GroupComponent groupComponent)
@@ -247,7 +273,7 @@ namespace ShipCoreFramework
                         var linkedPriority = usePriority ? linkedGroup.ShipCore.SpeedOverridePriority : 0;
                         var linkedDryMass = linkedGroup.GroupDryMass;
                         var linkedHasExplicitCore = linkedGroup.MainCoreComponent != null;
-                        var linkedTieBreaker = linkedGroup.GetRepresentativeGridId();
+                        var linkedTieBreaker = linkedGroup.GetCachedRepresentativeGridId();
 
                         var better = false;
                         if (bestSpeedGroup == null)
@@ -302,25 +328,17 @@ namespace ShipCoreFramework
             if (groupComponent == null || groupComponent.GridDictionary.Count == 0)
                 return new MyCubeGrid[0];
 
-            var grids = new List<MyCubeGrid>(groupComponent.GridDictionary.Count);
-            foreach (var grid in groupComponent.GridDictionary.Keys)
-            {
-                if (grid == null || grid.MarkedForClose || grid.Closed) continue;
-                if (grid.IsStatic) continue;
-                grids.Add(grid);
-            }
-
-            return grids.ToArray();
+            return groupComponent.GetCachedMovableGrids();
         }
 
         private static void EnsureSpeedStateUpdated(GroupComponent sourceGroup)
         {
             if (sourceGroup == null) return;
-            if (sourceGroup.LastSpeedStateUpdateTick == Session.CurrentTick) return;
+            if (Volatile.Read(ref sourceGroup.LastSpeedStateUpdateTick) == Session.CurrentTick) return;
 
             lock (sourceGroup.SpeedStateLock)
             {
-                if (sourceGroup.LastSpeedStateUpdateTick == Session.CurrentTick) return;
+                if (Volatile.Read(ref sourceGroup.LastSpeedStateUpdateTick) == Session.CurrentTick) return;
 
                 var activeCore = sourceGroup.ShipCore;
                 var speedModifiers = CubeGridModifiers.GetActiveSpeedModifiers(sourceGroup);
@@ -365,30 +383,15 @@ namespace ShipCoreFramework
                 sourceGroup.EffectiveSpeedLimitMetersPerSecond = effectiveMaxSpeed;
                 sourceGroup.EffectiveBoostEnabled = boostActive;
                 sourceGroup.SpeedSourceGroupGridId = GetSpeedSourceGridId(sourceGroup, sourceGroup);
-                sourceGroup.LastSpeedStateUpdateTick = Session.CurrentTick;
+                Volatile.Write(ref sourceGroup.LastSpeedStateUpdateTick, Session.CurrentTick);
             }
         }
 
         private static long GetSpeedSourceGridId(GroupComponent sourceGroup, GroupComponent fallbackGroup)
         {
-            var grid = sourceGroup?.MainCoreComponent?.GridComponent?.Grid
-                       ?? GetFirstGrid(sourceGroup)
-                       ?? fallbackGroup?.MainCoreComponent?.GridComponent?.Grid
-                       ?? GetFirstGrid(fallbackGroup);
-            return grid?.EntityId ?? 0;
-        }
-
-        private static MyCubeGrid GetFirstGrid(GroupComponent groupComponent)
-        {
-            if (groupComponent == null) return null;
-
-            foreach (var grid in groupComponent.GridDictionary.Keys)
-            {
-                if (grid == null || grid.MarkedForClose || grid.Closed) continue;
-                return grid;
-            }
-
-            return null;
+            var sourceGridId = sourceGroup?.GetCachedRepresentativeGridId() ?? 0;
+            if (sourceGridId != 0) return sourceGridId;
+            return fallbackGroup?.GetCachedRepresentativeGridId() ?? 0;
         }
 
         private static void EnforceContextOnGameThread(SpeedLimitContext context)

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Helpers/SpeedEnforcement.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Helpers/SpeedEnforcement.cs
@@ -133,7 +133,7 @@ namespace ShipCoreFramework
             EnsureSpeedStateUpdated(sourceGroup);
 
             var activeCore = sourceGroup.ShipCore;
-            var speedModifiers = CubeGridModifiers.GetActiveSpeedModifiers(sourceGroup);
+            var speedModifiers = sourceGroup.SpeedModifiers;
             float baseSpeedLimit;
             float effectiveSpeedLimit;
             bool effectiveBoostEnabled;
@@ -341,7 +341,7 @@ namespace ShipCoreFramework
                 if (Interlocked.CompareExchange(ref sourceGroup.LastSpeedStateUpdateTick, 0, 0) == Session.CurrentTick) return;
 
                 var activeCore = sourceGroup.ShipCore;
-                var speedModifiers = CubeGridModifiers.GetActiveSpeedModifiers(sourceGroup);
+                var speedModifiers = sourceGroup.SpeedModifiers;
                 var baseMaxSpeed = 100f;
                 var effectiveMaxSpeed = 100f;
                 var boostActive = sourceGroup.BoostEnabled;

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Helpers/SpeedEnforcement.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Helpers/SpeedEnforcement.cs
@@ -334,11 +334,11 @@ namespace ShipCoreFramework
         private static void EnsureSpeedStateUpdated(GroupComponent sourceGroup)
         {
             if (sourceGroup == null) return;
-            if (Volatile.Read(ref sourceGroup.LastSpeedStateUpdateTick) == Session.CurrentTick) return;
+            if (Interlocked.CompareExchange(ref sourceGroup.LastSpeedStateUpdateTick, 0, 0) == Session.CurrentTick) return;
 
             lock (sourceGroup.SpeedStateLock)
             {
-                if (Volatile.Read(ref sourceGroup.LastSpeedStateUpdateTick) == Session.CurrentTick) return;
+                if (Interlocked.CompareExchange(ref sourceGroup.LastSpeedStateUpdateTick, 0, 0) == Session.CurrentTick) return;
 
                 var activeCore = sourceGroup.ShipCore;
                 var speedModifiers = CubeGridModifiers.GetActiveSpeedModifiers(sourceGroup);
@@ -383,7 +383,7 @@ namespace ShipCoreFramework
                 sourceGroup.EffectiveSpeedLimitMetersPerSecond = effectiveMaxSpeed;
                 sourceGroup.EffectiveBoostEnabled = boostActive;
                 sourceGroup.SpeedSourceGroupGridId = GetSpeedSourceGridId(sourceGroup, sourceGroup);
-                Volatile.Write(ref sourceGroup.LastSpeedStateUpdateTick, Session.CurrentTick);
+                Interlocked.Exchange(ref sourceGroup.LastSpeedStateUpdateTick, Session.CurrentTick);
             }
         }
 

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Helpers/Utils.BlockActions.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Helpers/Utils.BlockActions.cs
@@ -14,6 +14,24 @@ namespace ShipCoreFramework
     {
         internal static void RemoveAndRefund(this IMySlimBlock block)
         {
+            if (!Session.IsGameThread)
+            {
+                var capturedBlock = block;
+                var blockId = capturedBlock?.FatBlock == null ? 0 : capturedBlock.FatBlock.EntityId;
+                var coalesceKey = blockId == 0 ? string.Empty : "remove-refund:" + blockId;
+                ThreadWork.Enqueue(ThreadWork.StateCategory, coalesceKey,
+                    "Remove and refund block " + blockId,
+                    delegate
+                    {
+                        return capturedBlock?.CubeGrid != null &&
+                               !capturedBlock.CubeGrid.MarkedForClose &&
+                               !capturedBlock.CubeGrid.Closed &&
+                               !Session.IsShuttingDown;
+                    },
+                    delegate { RemoveAndRefund(capturedBlock); });
+                return;
+            }
+
             var grid = block?.CubeGrid;
             if (grid == null) return;
 

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Helpers/Utils.Grid.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Helpers/Utils.Grid.cs
@@ -111,9 +111,21 @@ namespace ShipCoreFramework
 
         internal static bool TryFindByGridId(long gridEntityId, out GroupComponent group)
         {
-            foreach (var gc in Session.GroupDict.Select(kv => kv.Value)
-                         .Where(gc => gc.GridDictionary.Keys.Any(g => g != null && g.EntityId == gridEntityId)))
+            foreach (var gc in Session.GroupDict.Select(kv => kv.Value))
             {
+                var gridIds = gc.GetCachedMechanicalGridIds();
+                for (var i = 0; i < gridIds.Length; i++)
+                {
+                    if (gridIds[i] != gridEntityId) continue;
+                    group = gc;
+                    return true;
+                }
+            }
+
+            foreach (var gc in Session.GroupDict.Select(kv => kv.Value))
+            {
+                if (!Session.IsGameThread) continue;
+                if (!gc.GridDictionary.Keys.Any(g => g != null && g.EntityId == gridEntityId)) continue;
                 group = gc;
                 return true;
             }

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Helpers/Utils.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Helpers/Utils.cs
@@ -26,7 +26,7 @@ namespace ShipCoreFramework
                 if (inner == null) continue;
 
                 foreach (var kvp in inner)
-                    result.Add(kvp.Key, kvp.Value);
+                    result[kvp.Key] = kvp.Value;
             }
 
             return result;

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Managers/CoreCountKey.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Managers/CoreCountKey.cs
@@ -1,0 +1,48 @@
+using System;
+
+namespace ShipCoreFramework
+{
+    internal struct CoreCountKey : IEquatable<CoreCountKey>
+    {
+        internal long OwnerId;
+        internal string CoreType;
+
+        internal CoreCountKey(long ownerId, string coreType)
+        {
+            OwnerId = ownerId;
+            CoreType = coreType ?? string.Empty;
+        }
+
+        public bool Equals(CoreCountKey other)
+        {
+            return OwnerId == other.OwnerId &&
+                   string.Equals(CoreType, other.CoreType, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is CoreCountKey && Equals((CoreCountKey)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (OwnerId.GetHashCode() * 397) ^
+                       StringComparer.OrdinalIgnoreCase.GetHashCode(CoreType ?? string.Empty);
+            }
+        }
+
+        public override string ToString()
+        {
+            return OwnerId + ":" + (CoreType ?? string.Empty);
+        }
+    }
+
+    internal struct CoreCountEntry
+    {
+        internal long OwnerId;
+        internal string CoreType;
+        internal int Count;
+    }
+}

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Managers/PerFactionManager.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Managers/PerFactionManager.cs
@@ -15,7 +15,9 @@ namespace ShipCoreFramework
             internal int Count;
         }
 
-        internal static readonly Dictionary<long, Dictionary<string, int>> PerFaction = new Dictionary<long, Dictionary<string, int>>();
+        private static readonly GameThreadWriteDictionary<CoreCountKey, int> PerFactionCounts =
+            new GameThreadWriteDictionary<CoreCountKey, int>(null, ThreadWork.CountsCategory, "faction-counts");
+
         private static bool _suppressEvents;
 
         private static ModConfig Config => Session.Config;
@@ -141,103 +143,119 @@ namespace ShipCoreFramework
             if (factionId <= 0 || string.IsNullOrWhiteSpace(coreType))
                 return 0;
 
-            Dictionary<string, int> perGroup;
-            if (!PerFaction.TryGetValue(factionId, out perGroup))
-            {
-                perGroup = GetDefaultFactionGridsSet();
-                PerFaction[factionId] = perGroup;
-            }
-
-            int count;
-            if (perGroup.TryGetValue(coreType, out count))
-                return count + LimitsNexusSync.GetRemoteFactionCount(factionId, coreType);
-
-            perGroup[coreType] = 0;
-            return LimitsNexusSync.GetRemoteFactionCount(factionId, coreType);
+            var localCount = PerFactionCounts.GetOrDefault(new CoreCountKey(factionId, coreType), 0);
+            return localCount + LimitsNexusSync.GetRemoteFactionCount(factionId, coreType);
         }
 
         internal static void AddGridGroup(IMyFaction owningFaction, string coreType)
         {
-            Utils.Log($"PerFactionManager::AddCubeGrid: Adding grid for faction {owningFaction?.FactionId} with core type {coreType}", 1);
             if (owningFaction == null) return;
+            AddGridGroup(owningFaction.FactionId, coreType);
+        }
 
-            Dictionary<string, int> perGroup;
-            if (!PerFaction.TryGetValue(owningFaction.FactionId, out perGroup))
+        internal static void AddGridGroup(long factionId, string coreType)
+        {
+            if (!Session.IsGameThread)
             {
-                perGroup = GetDefaultFactionGridsSet();
-                PerFaction[owningFaction.FactionId] = perGroup;
+                ThreadWork.Enqueue(ThreadWork.CountsCategory, string.Empty,
+                    "Add faction core count", delegate { AddGridGroup(factionId, coreType); });
+                return;
             }
 
-            if (!perGroup.ContainsKey(coreType))
-            {
-                Utils.Log($"PerFactionManager::AddCubeGrid: Missing entry for core type {coreType} in faction {owningFaction.FactionId}", 1);
-                perGroup[coreType] = 0;
-            }
+            Utils.Log($"PerFactionManager::AddCubeGrid: Adding grid for faction {factionId} with core type {coreType}", 1);
+            if (factionId <= 0 || string.IsNullOrWhiteSpace(coreType)) return;
 
-            perGroup[coreType]++;
-            if (!_suppressEvents) LimitsNexusSync.BroadcastFactionChange(new FactionChange { FactionId = owningFaction.FactionId, CoreType = coreType, Count = perGroup[coreType] });
+            var key = new CoreCountKey(factionId, coreType);
+            var count = PerFactionCounts.AddOrUpdate(key, 1, delegate(CoreCountKey k, int value) { return value + 1; });
+            if (!_suppressEvents) LimitsNexusSync.BroadcastFactionChange(new FactionChange { FactionId = factionId, CoreType = coreType, Count = count });
         }
 
         internal static void RemoveGridGroup(IMyFaction owningFaction, string coreType)
         {
             if (owningFaction == null) return;
-
             RemoveGridGroup(owningFaction.FactionId, coreType);
         }
 
         internal static void RemoveGridGroup(long factionId, string coreType)
         {
-            if (factionId <= 0) return;
+            if (!Session.IsGameThread)
+            {
+                ThreadWork.Enqueue(ThreadWork.CountsCategory, string.Empty,
+                    "Remove faction core count", delegate { RemoveGridGroup(factionId, coreType); });
+                return;
+            }
 
-            Dictionary<string, int> perGroup;
-            if (!PerFaction.TryGetValue(factionId, out perGroup)) return;
+            if (factionId <= 0 || string.IsNullOrWhiteSpace(coreType)) return;
 
-            int value;
-            if (!perGroup.TryGetValue(coreType, out value)) return;
-            if (value <= 0) return;
+            var key = new CoreCountKey(factionId, coreType);
+            var previous = PerFactionCounts.GetOrDefault(key, 0);
+            if (previous <= 0) return;
 
-            perGroup[coreType]--;
-            if (!_suppressEvents) LimitsNexusSync.BroadcastFactionChange(new FactionChange { FactionId = factionId, CoreType = coreType, Count = perGroup[coreType] });
+            var count = PerFactionCounts.AddOrUpdate(key, 0,
+                delegate(CoreCountKey k, int value) { return value <= 0 ? 0 : value - 1; });
+            if (!_suppressEvents) LimitsNexusSync.BroadcastFactionChange(new FactionChange { FactionId = factionId, CoreType = coreType, Count = count });
         }
 
         internal static void RemoveFaction(long factionId)
         {
+            if (!Session.IsGameThread)
+            {
+                ThreadWork.Enqueue(ThreadWork.CountsCategory, "faction-remove:" + factionId,
+                    "Remove faction counts", delegate { RemoveFaction(factionId); });
+                return;
+            }
+
             if (factionId <= 0) return;
 
-            Dictionary<string, int> perGroup;
-            if (!PerFaction.TryGetValue(factionId, out perGroup)) return;
-
-            foreach (var coreType in perGroup.Keys.ToList())
+            foreach (var entry in GetFactionCountsSnapshot(factionId).ToList())
             {
-                var value = perGroup[coreType];
-                if (value <= 0) continue;
-
-                perGroup[coreType] = 0;
-                if (!_suppressEvents) LimitsNexusSync.BroadcastFactionChange(new FactionChange { FactionId = factionId, CoreType = coreType, Count = 0 });
+                if (entry.Value <= 0) continue;
+                PerFactionCounts.Set(new CoreCountKey(factionId, entry.Key), 0);
+                if (!_suppressEvents) LimitsNexusSync.BroadcastFactionChange(new FactionChange { FactionId = factionId, CoreType = entry.Key, Count = 0 });
             }
         }
 
         internal static void Reset()
         {
-            foreach (var factionEntry in PerFaction.Values)
+            if (!Session.IsGameThread)
             {
-                foreach (var key in factionEntry.Keys.ToList())
-                {
-                    factionEntry[key] = 0;
-                }
+                ThreadWork.Enqueue(ThreadWork.CountsCategory, "faction-reset", "Reset faction core counts", Reset);
+                return;
             }
+
+            PerFactionCounts.Clear();
+        }
+
+        internal static CoreCountEntry[] GetLocalCountsSnapshot()
+        {
+            var snapshot = PerFactionCounts.ToArraySnapshot();
+            var result = new CoreCountEntry[snapshot.Length];
+            for (var i = 0; i < snapshot.Length; i++)
+            {
+                result[i] = new CoreCountEntry
+                {
+                    OwnerId = snapshot[i].Key.OwnerId,
+                    CoreType = snapshot[i].Key.CoreType,
+                    Count = snapshot[i].Value
+                };
+            }
+
+            return result;
+        }
+
+        internal static Dictionary<string, int> GetFactionCountsSnapshot(long factionId)
+        {
+            var result = new Dictionary<string, int>();
+            foreach (var entry in GetLocalCountsSnapshot())
+            {
+                if (entry.OwnerId != factionId) continue;
+                result[entry.CoreType] = entry.Count;
+            }
+
+            return result;
         }
 
         internal static void BeginExternalUpdate() { _suppressEvents = true; }
         internal static void EndExternalUpdate() { _suppressEvents = false; }
-
-        private static Dictionary<string, int> GetDefaultFactionGridsSet()
-        {
-            var set = new Dictionary<string, int>();
-            foreach (var core in Config.ShipCores) set[core.SubtypeId] = 0;
-            if (Config.SelectedNoCore != null && !string.IsNullOrWhiteSpace(Config.SelectedNoCore.SubtypeId))
-                set[Config.SelectedNoCore.SubtypeId] = 0;
-            return set;
-        }
     }
 }

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Managers/PerManifestGroupManager.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Managers/PerManifestGroupManager.cs
@@ -12,8 +12,14 @@ namespace ShipCoreFramework
             internal int Count;
         }
 
-        internal static readonly Dictionary<string, int> PerManifestGroup =
-            new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        internal struct ManifestGroupCountEntry
+        {
+            internal string GroupName;
+            internal int Count;
+        }
+
+        private static readonly GameThreadWriteDictionary<string, int> PerManifestGroupCounts =
+            new GameThreadWriteDictionary<string, int>(StringComparer.OrdinalIgnoreCase, ThreadWork.CountsCategory, "manifest-group-counts");
 
         private static bool _suppressEvents;
 
@@ -29,8 +35,7 @@ namespace ShipCoreFramework
             if (string.IsNullOrWhiteSpace(groupName))
                 return 0;
 
-            int count;
-            return (PerManifestGroup.TryGetValue(groupName, out count) ? count : 0) +
+            return PerManifestGroupCounts.GetOrDefault(groupName, 0) +
                    LimitsNexusSync.GetRemoteManifestGroupCount(groupName);
         }
 
@@ -63,59 +68,92 @@ namespace ShipCoreFramework
 
         internal static void AddGridGroup(string coreType)
         {
+            if (!Session.IsGameThread)
+            {
+                ThreadWork.Enqueue(ThreadWork.CountsCategory, string.Empty,
+                    "Add manifest group counts", delegate { AddGridGroup(coreType); });
+                return;
+            }
+
             var core = Config.GetShipCoreByTypeId(coreType);
             if (!HasManifestGroupLimit(core))
                 return;
 
             foreach (var group in GetManifestGroups(core))
             {
-                if (!PerManifestGroup.ContainsKey(group.Name))
-                    PerManifestGroup[group.Name] = 0;
-
-                PerManifestGroup[group.Name]++;
+                var count = PerManifestGroupCounts.AddOrUpdate(group.Name, 1,
+                    delegate(string key, int value) { return value + 1; });
                 if (_suppressEvents)
                     continue;
 
                 LimitsNexusSync.BroadcastManifestGroupChange(new ManifestGroupChange
                 {
                     GroupName = group.Name,
-                    Count = PerManifestGroup[group.Name]
+                    Count = count
                 });
             }
         }
 
         internal static void RemoveGridGroup(string coreType)
         {
+            if (!Session.IsGameThread)
+            {
+                ThreadWork.Enqueue(ThreadWork.CountsCategory, string.Empty,
+                    "Remove manifest group counts", delegate { RemoveGridGroup(coreType); });
+                return;
+            }
+
             var core = Config.GetShipCoreByTypeId(coreType);
             if (!HasManifestGroupLimit(core))
                 return;
 
             foreach (var group in GetManifestGroups(core))
             {
-                int value;
-                if (!PerManifestGroup.TryGetValue(group.Name, out value) || value <= 0)
+                var previous = PerManifestGroupCounts.GetOrDefault(group.Name, 0);
+                if (previous <= 0)
                     continue;
 
-                PerManifestGroup[group.Name]--;
+                var count = PerManifestGroupCounts.AddOrUpdate(group.Name, 0,
+                    delegate(string key, int value) { return value <= 0 ? 0 : value - 1; });
                 if (_suppressEvents)
                     continue;
 
                 LimitsNexusSync.BroadcastManifestGroupChange(new ManifestGroupChange
                 {
                     GroupName = group.Name,
-                    Count = PerManifestGroup[group.Name]
+                    Count = count
                 });
             }
         }
 
         internal static void Reset()
         {
-            foreach (var key in PerManifestGroup.Keys.ToList())
-                PerManifestGroup[key] = 0;
+            if (!Session.IsGameThread)
+            {
+                ThreadWork.Enqueue(ThreadWork.CountsCategory, "manifest-reset", "Reset manifest group counts", Reset);
+                return;
+            }
+
+            PerManifestGroupCounts.Clear();
 
             foreach (var group in Config.ManifestCoreGroups.Where(group => group != null && !string.IsNullOrWhiteSpace(group.Name)))
-                if (!PerManifestGroup.ContainsKey(group.Name))
-                    PerManifestGroup[group.Name] = 0;
+                PerManifestGroupCounts.Set(group.Name, 0);
+        }
+
+        internal static ManifestGroupCountEntry[] GetLocalCountsSnapshot()
+        {
+            var snapshot = PerManifestGroupCounts.ToArraySnapshot();
+            var result = new ManifestGroupCountEntry[snapshot.Length];
+            for (var i = 0; i < snapshot.Length; i++)
+            {
+                result[i] = new ManifestGroupCountEntry
+                {
+                    GroupName = snapshot[i].Key,
+                    Count = snapshot[i].Value
+                };
+            }
+
+            return result;
         }
 
         internal static void BeginExternalUpdate()

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Managers/PerPlayerManager.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Managers/PerPlayerManager.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System;
+using System.Collections.Generic;
 
 namespace ShipCoreFramework
 {
@@ -12,7 +12,9 @@ namespace ShipCoreFramework
             internal int Count;
         }
 
-        internal static readonly Dictionary<long, Dictionary<string, int>> PerPlayer = new Dictionary<long, Dictionary<string, int>>();
+        private static readonly GameThreadWriteDictionary<CoreCountKey, int> PerPlayerCounts =
+            new GameThreadWriteDictionary<CoreCountKey, int>(null, ThreadWork.CountsCategory, "player-counts");
+
         private static bool _suppressEvents;
 
         private static ModConfig Config => Session.Config;
@@ -40,80 +42,89 @@ namespace ShipCoreFramework
             if (ownerId <= 0 || string.IsNullOrWhiteSpace(coreType))
                 return 0;
 
-            Dictionary<string, int> perGridClass;
-            if (!PerPlayer.TryGetValue(ownerId, out perGridClass))
-            {
-                perGridClass = GetDefaultPlayerGridsSet();
-                PerPlayer[ownerId] = perGridClass;
-            }
-
-            int count;
-            if (perGridClass.TryGetValue(coreType, out count))
-                return count + LimitsNexusSync.GetRemotePlayerCount(ownerId, coreType);
-
-            perGridClass[coreType] = 0;
-            return LimitsNexusSync.GetRemotePlayerCount(ownerId, coreType);
+            var localCount = PerPlayerCounts.GetOrDefault(new CoreCountKey(ownerId, coreType), 0);
+            return localCount + LimitsNexusSync.GetRemotePlayerCount(ownerId, coreType);
         }
 
         internal static void AddGridGroup(long ownerId, string coreType)
         {
+            if (!Session.IsGameThread)
+            {
+                ThreadWork.Enqueue(ThreadWork.CountsCategory, string.Empty,
+                    "Add player core count", delegate { AddGridGroup(ownerId, coreType); });
+                return;
+            }
+
             Utils.Log($"PerPlayerManager::AddCubeGrid: Adding grid for player {ownerId} with core type {coreType}", 1);
-            if (ownerId <= 0) return;
+            if (ownerId <= 0 || string.IsNullOrWhiteSpace(coreType)) return;
 
-            Dictionary<string, int> perGridClass;
-            if (!PerPlayer.TryGetValue(ownerId, out perGridClass))
-            {
-                perGridClass = GetDefaultPlayerGridsSet();
-                PerPlayer[ownerId] = perGridClass;
-            }
-
-            if (!perGridClass.ContainsKey(coreType))
-            {
-                Utils.Log($"PerPlayerManager::AddCubeGrid: Missing entry for core type {coreType} for player {ownerId}", 1);
-                perGridClass[coreType] = 0;
-            }
-
-            perGridClass[coreType]++;
-            Utils.Log($"PerPlayerManager::AddCubeGrid: Player {ownerId} now has {perGridClass[coreType]} grids with {coreType}", 1);
-            if (!_suppressEvents) LimitsNexusSync.BroadcastPlayerChange(new PlayerChange { PlayerId = ownerId, CoreType = coreType, Count = perGridClass[coreType] });
+            var key = new CoreCountKey(ownerId, coreType);
+            var count = PerPlayerCounts.AddOrUpdate(key, 1, delegate(CoreCountKey k, int value) { return value + 1; });
+            Utils.Log($"PerPlayerManager::AddCubeGrid: Player {ownerId} now has {count} grids with {coreType}", 1);
+            if (!_suppressEvents) LimitsNexusSync.BroadcastPlayerChange(new PlayerChange { PlayerId = ownerId, CoreType = coreType, Count = count });
         }
 
         internal static void RemoveGridGroup(long ownerId, string coreType)
         {
-            if (ownerId <= 0) return;
-            
-            Dictionary<string, int> perGridClass;
-            if (!PerPlayer.TryGetValue(ownerId, out perGridClass)) return;
-            
-            int value;
-            if (!perGridClass.TryGetValue(coreType, out value)) return;
-            if (value <= 0) return;
+            if (!Session.IsGameThread)
+            {
+                ThreadWork.Enqueue(ThreadWork.CountsCategory, string.Empty,
+                    "Remove player core count", delegate { RemoveGridGroup(ownerId, coreType); });
+                return;
+            }
 
-            perGridClass[coreType]--;
-            if (!_suppressEvents) LimitsNexusSync.BroadcastPlayerChange(new PlayerChange { PlayerId = ownerId, CoreType = coreType, Count = perGridClass[coreType] });
+            if (ownerId <= 0 || string.IsNullOrWhiteSpace(coreType)) return;
+
+            var key = new CoreCountKey(ownerId, coreType);
+            var previous = PerPlayerCounts.GetOrDefault(key, 0);
+            if (previous <= 0) return;
+
+            var count = PerPlayerCounts.AddOrUpdate(key, 0,
+                delegate(CoreCountKey k, int value) { return value <= 0 ? 0 : value - 1; });
+            if (!_suppressEvents) LimitsNexusSync.BroadcastPlayerChange(new PlayerChange { PlayerId = ownerId, CoreType = coreType, Count = count });
         }
 
         internal static void Reset()
         {
-            foreach (var classesEntry in PerPlayer.Values)
+            if (!Session.IsGameThread)
             {
-                foreach (var key in classesEntry.Keys.ToList())
-                {
-                    classesEntry[key] = 0;
-                }
+                ThreadWork.Enqueue(ThreadWork.CountsCategory, "player-reset", "Reset player core counts", Reset);
+                return;
             }
+
+            PerPlayerCounts.Clear();
+        }
+
+        internal static CoreCountEntry[] GetLocalCountsSnapshot()
+        {
+            var snapshot = PerPlayerCounts.ToArraySnapshot();
+            var result = new CoreCountEntry[snapshot.Length];
+            for (var i = 0; i < snapshot.Length; i++)
+            {
+                result[i] = new CoreCountEntry
+                {
+                    OwnerId = snapshot[i].Key.OwnerId,
+                    CoreType = snapshot[i].Key.CoreType,
+                    Count = snapshot[i].Value
+                };
+            }
+
+            return result;
+        }
+
+        internal static Dictionary<string, int> GetPlayerCountsSnapshot(long ownerId)
+        {
+            var result = new Dictionary<string, int>();
+            foreach (var entry in GetLocalCountsSnapshot())
+            {
+                if (entry.OwnerId != ownerId) continue;
+                result[entry.CoreType] = entry.Count;
+            }
+
+            return result;
         }
 
         internal static void BeginExternalUpdate() { _suppressEvents = true; }
         internal static void EndExternalUpdate() { _suppressEvents = false; }
-
-        private static Dictionary<string, int> GetDefaultPlayerGridsSet()
-        {
-            var set = new Dictionary<string, int>();
-            foreach (var core in Config.ShipCores) set[core.SubtypeId] = 0;
-            if (Config.SelectedNoCore != null && !string.IsNullOrWhiteSpace(Config.SelectedNoCore.SubtypeId))
-                set[Config.SelectedNoCore.SubtypeId] = 0;
-            return set;
-        }
     }
 }

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Network/LimitsNexusSync.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Network/LimitsNexusSync.cs
@@ -128,6 +128,7 @@ namespace ShipCoreFramework
         internal static void BroadcastSnapshot()
         {
             if (!Ready) return;
+            if (Session.IsGameThread) ThreadWork.FlushPendingWrites(ThreadWork.CountsCategory);
             var env = new Envelope { Kind = EnvelopeKind.Snapshot, Payload = Serialize(BuildSnapshot()) };
             _nexus.SendModMsgToAllServers(Serialize(env), ChannelId);
         }
@@ -221,24 +222,36 @@ namespace ShipCoreFramework
         {
             var s = new LimitsState();
 
-            foreach (var f in PerFactionManager.PerFaction)
+            var factions = new Dictionary<long, FactionEntry>();
+            foreach (var count in PerFactionManager.GetLocalCountsSnapshot())
             {
-                var fe = new FactionEntry { FactionId = f.Key };
-                foreach (var kv in f.Value)
-                    fe.Cores.Add(new CoreEntry { CoreType = kv.Key, Count = kv.Value });
-                s.Factions.Add(fe);
+                FactionEntry entry;
+                if (!factions.TryGetValue(count.OwnerId, out entry))
+                {
+                    entry = new FactionEntry { FactionId = count.OwnerId };
+                    factions[count.OwnerId] = entry;
+                    s.Factions.Add(entry);
+                }
+
+                entry.Cores.Add(new CoreEntry { CoreType = count.CoreType, Count = count.Count });
             }
 
-            foreach (var p in PerPlayerManager.PerPlayer)
+            var players = new Dictionary<long, PlayerEntry>();
+            foreach (var count in PerPlayerManager.GetLocalCountsSnapshot())
             {
-                var pe = new PlayerEntry { PlayerId = p.Key };
-                foreach (var kv in p.Value)
-                    pe.Cores.Add(new CoreEntry { CoreType = kv.Key, Count = kv.Value });
-                s.Players.Add(pe);
+                PlayerEntry entry;
+                if (!players.TryGetValue(count.OwnerId, out entry))
+                {
+                    entry = new PlayerEntry { PlayerId = count.OwnerId };
+                    players[count.OwnerId] = entry;
+                    s.Players.Add(entry);
+                }
+
+                entry.Cores.Add(new CoreEntry { CoreType = count.CoreType, Count = count.Count });
             }
 
-            foreach (var g in PerManifestGroupManager.PerManifestGroup)
-                s.ManifestGroups.Add(new ManifestGroupEntry { GroupName = g.Key, Count = g.Value });
+            foreach (var count in PerManifestGroupManager.GetLocalCountsSnapshot())
+                s.ManifestGroups.Add(new ManifestGroupEntry { GroupName = count.GroupName, Count = count.Count });
 
             return s;
         }

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Session/Session.Events.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Session/Session.Events.cs
@@ -39,7 +39,8 @@ namespace ShipCoreFramework
             group.OnGridAdded += gComp.OnGridAdded;
             group.OnGridRemoved += gComp.OnGridRemoved;
 
-            RefreshPhysicalGroupLinkagesForGrids(tempGridList);
+            if (!IsInitialGroupScan)
+                RefreshPhysicalGroupLinkagesForGrids(tempGridList);
         }
         
         private static void GridGroupsOnOnGridGroupDestroyed(IMyGridGroupData group)

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Session/Session.Events.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Session/Session.Events.cs
@@ -11,6 +11,11 @@ namespace ShipCoreFramework
         private static void GridGroupsOnOnGridGroupCreated(IMyGridGroupData group)
         {
             if (group == null) return;
+            if (!IsGameThread && !IsInitialGroupScan)
+            {
+                MyAPIGateway.Utilities.InvokeOnGameThread(() => GridGroupsOnOnGridGroupCreated(group));
+                return;
+            }
 
             if (group.LinkType == GridLinkTypeEnum.Physical)
             {
@@ -46,6 +51,11 @@ namespace ShipCoreFramework
         private static void GridGroupsOnOnGridGroupDestroyed(IMyGridGroupData group)
         {
             if (group == null) return;
+            if (!IsGameThread)
+            {
+                MyAPIGateway.Utilities.InvokeOnGameThread(() => GridGroupsOnOnGridGroupDestroyed(group));
+                return;
+            }
 
             if (group.LinkType == GridLinkTypeEnum.Physical)
             {

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Session/Session.Fields.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Session/Session.Fields.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Concurrent;
-using System.Threading;
 using NexusModAPI;
 using Sandbox.ModAPI;
 using VRage.Game.ModAPI;
@@ -35,6 +34,6 @@ namespace ShipCoreFramework
         internal static readonly Guid CoreLastOwnerStorageGUID = new Guid("3521026e-9025-4c62-9de7-98379fd2439d");
         
         internal static IMyPlayer LocalPlayer => MyAPIGateway.Session.LocalHumanPlayer;
-        internal static bool IsGameThread => GameThreadId != 0 && Thread.CurrentThread.ManagedThreadId == GameThreadId;
+        internal static bool IsGameThread => GameThreadId != 0 && Environment.CurrentManagedThreadId == GameThreadId;
     }
 }

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Session/Session.Fields.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Session/Session.Fields.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Threading;
 using NexusModAPI;
 using Sandbox.ModAPI;
 using VRage.Game.ModAPI;
@@ -10,6 +11,7 @@ namespace ShipCoreFramework
     public partial class Session
     {
         private static NexusAPI _myNexusApi;
+        private const int MaxQueuedStateWorkPerTick = 64;
         private bool _startedNexus;
         private int _tick;
         internal static int CurrentTick;
@@ -22,6 +24,8 @@ namespace ShipCoreFramework
         internal static bool MpActive;
         internal static bool HasStarted;
         internal static bool IsShuttingDown;
+        internal static volatile bool IsInitialGroupScan;
+        internal static int GameThreadId;
         internal static ModConfig Config = new ModConfig();
         internal static Networking Networking = new Networking(32124);
         internal static float AppliedSpeedDifferential;
@@ -31,5 +35,6 @@ namespace ShipCoreFramework
         internal static readonly Guid CoreLastOwnerStorageGUID = new Guid("3521026e-9025-4c62-9de7-98379fd2439d");
         
         internal static IMyPlayer LocalPlayer => MyAPIGateway.Session.LocalHumanPlayer;
+        internal static bool IsGameThread => GameThreadId != 0 && Thread.CurrentThread.ManagedThreadId == GameThreadId;
     }
 }

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Session/Session.PhysicalGroups.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Session/Session.PhysicalGroups.cs
@@ -138,7 +138,11 @@ namespace ShipCoreFramework
 
                 GroupComponent groupComponent;
                 if (GroupDict.TryGetValue(mechanicalGroup, out groupComponent) && groupComponent != null)
+                {
+                    if (IsGameThread)
+                        groupComponent.RefreshGameThreadStateCache();
                     memberGroups.Add(groupComponent);
+                }
             }
 
             var cluster = PhysicalSpeedClusterDict.GetOrAdd(physicalGroup,
@@ -167,7 +171,7 @@ namespace ShipCoreFramework
 
             var nextMembers = memberGroups
                 .Distinct()
-                .OrderBy(group => group.GetRepresentativeGridId())
+                .OrderBy(group => group.GetCachedRepresentativeGridId())
                 .ToArray();
 
             var representativeGroup = nextMembers.FirstOrDefault();
@@ -229,6 +233,10 @@ namespace ShipCoreFramework
         {
             if (groupComponent == null || physicalGridIds == null) return false;
 
+            var cachedGridIds = groupComponent.GetCachedMechanicalGridIds();
+            if (cachedGridIds.Length > 0)
+                return new HashSet<long>(cachedGridIds).SetEquals(physicalGridIds);
+
             var mechanicalGridIds = new HashSet<long>();
             foreach (var grid in groupComponent.GridDictionary.Keys)
             {
@@ -247,6 +255,19 @@ namespace ShipCoreFramework
             foreach (var groupComponent in memberGroups)
             {
                 if (groupComponent == null) continue;
+
+                var cachedMovableGrids = groupComponent.GetCachedMovableGrids();
+                if (cachedMovableGrids.Length > 0)
+                {
+                    foreach (var grid in cachedMovableGrids)
+                    {
+                        if (grid == null) continue;
+                        if (!seenGridIds.Add(grid.EntityId)) continue;
+                        grids.Add(grid);
+                    }
+
+                    continue;
+                }
 
                 foreach (var grid in groupComponent.GridDictionary.Keys)
                 {

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Session/Session.Run.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Session/Session.Run.cs
@@ -32,22 +32,29 @@ namespace ShipCoreFramework
             MyAPIGateway.GridGroups.GetGridGroups(GridLinkTypeEnum.Mechanical, mechanicalGroups);
             MyAPIGateway.GridGroups.GetGridGroups(GridLinkTypeEnum.Physical, physicalGroups);
 
-            MyAPIGateway.Parallel.StartBackground(() =>
+            IsInitialGroupScan = true;
+            try
             {
-                foreach (var group in mechanicalGroups)
+                MyAPIGateway.Parallel.ForEach(mechanicalGroups, mechanicalGroup =>
                 {
-                    GridGroupsOnOnGridGroupCreated(group);
-                }
+                    GridGroupsOnOnGridGroupCreated(mechanicalGroup);
+                });
 
-                foreach (var group in physicalGroups)
+                MyAPIGateway.Parallel.ForEach(physicalGroups, physicalGroup =>
                 {
-                    GridGroupsOnOnGridGroupCreated(group);
-                }
-            });
+                    GridGroupsOnOnGridGroupCreated(physicalGroup);
+                });
+            }
+            finally
+            {
+                IsInitialGroupScan = false;
+            }
         }
         
         public override void LoadData()
         {
+            GameThreadId = System.Threading.Thread.CurrentThread.ManagedThreadId;
+            IsShuttingDown = false;
             MpActive = MyAPIGateway.Multiplayer.MultiplayerActive;
             IsServer = (MpActive && MyAPIGateway.Multiplayer.IsServer) || !MpActive;
             IsClient = (MpActive && !MyAPIGateway.Utilities.IsDedicated) || !MpActive;
@@ -83,6 +90,7 @@ namespace ShipCoreFramework
         protected override void UnloadData()
         {
             IsShuttingDown = true;
+            ThreadWork.CancelAll("Session unload");
             MyAPIGateway.Session.OnSessionReady -= SessionReady;
             MyAPIGateway.Session.Factions.FactionStateChanged -= FactionStateChanged;
             MyAPIGateway.Utilities.MessageEnteredSender -= Commands.OnChatCommand;
@@ -113,12 +121,14 @@ namespace ShipCoreFramework
             if (IsServer) Config.SaveConfig();
             Networking?.Unregister();
             Networking = null;
+            ThreadWork.Clear();
             
             foreach (var kvp in GroupDict)
             {
                 kvp.Value.Clean();
             }
             GroupDict.Clear();
+            GameThreadId = 0;
         }
         
         private void OnNexusEnabled()
@@ -165,6 +175,10 @@ namespace ShipCoreFramework
 
             _tick++;
             CurrentTick = _tick;
+            ThreadWork.FlushPendingWrites(ThreadWork.CountsCategory);
+            ThreadWork.FlushPendingWrites(null, MaxQueuedStateWorkPerTick);
+            foreach (var group in GroupDict.Values)
+                group.RefreshGameThreadStateCache();
             if (IsServer) LimitsNexusSync.RunPeriodicSnapshotTick();
             var runNfz = _tick % 10 == 0;
             var doPunish = _tick % 60 == 0;

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Session/Session.Run.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Session/Session.Run.cs
@@ -53,7 +53,7 @@ namespace ShipCoreFramework
         
         public override void LoadData()
         {
-            GameThreadId = System.Threading.Thread.CurrentThread.ManagedThreadId;
+            GameThreadId = Environment.CurrentManagedThreadId;
             IsShuttingDown = false;
             MpActive = MyAPIGateway.Multiplayer.MultiplayerActive;
             IsServer = (MpActive && MyAPIGateway.Multiplayer.IsServer) || !MpActive;

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Threading/GameThreadWriteDictionary.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Threading/GameThreadWriteDictionary.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace ShipCoreFramework
+{
+    internal sealed class GameThreadWriteDictionary<TKey, TValue>
+    {
+        private readonly ConcurrentDictionary<TKey, TValue> _items;
+        private readonly string _category;
+        private readonly string _name;
+
+        internal GameThreadWriteDictionary()
+            : this(null, null, null)
+        {
+        }
+
+        internal GameThreadWriteDictionary(IEqualityComparer<TKey> comparer)
+            : this(comparer, null, null)
+        {
+        }
+
+        internal GameThreadWriteDictionary(IEqualityComparer<TKey> comparer, string category, string name)
+        {
+            _items = comparer == null
+                ? new ConcurrentDictionary<TKey, TValue>()
+                : new ConcurrentDictionary<TKey, TValue>(comparer);
+            _category = category ?? ThreadWork.StateCategory;
+            _name = name ?? "dictionary";
+        }
+
+        internal int Count
+        {
+            get { return _items.Count; }
+        }
+
+        internal bool TryGetValue(TKey key, out TValue value)
+        {
+            return _items.TryGetValue(key, out value);
+        }
+
+        internal bool ContainsKey(TKey key)
+        {
+            return _items.ContainsKey(key);
+        }
+
+        internal TValue GetOrDefault(TKey key, TValue defaultValue)
+        {
+            TValue value;
+            return _items.TryGetValue(key, out value) ? value : defaultValue;
+        }
+
+        internal KeyValuePair<TKey, TValue>[] ToArraySnapshot()
+        {
+            return _items.ToArray();
+        }
+
+        internal TValue[] ValuesSnapshot()
+        {
+            var values = _items.Values;
+            var result = new TValue[values.Count];
+            values.CopyTo(result, 0);
+            return result;
+        }
+
+        internal void Set(TKey key, TValue value)
+        {
+            RunOrQueue("set", key, delegate { _items[key] = value; });
+        }
+
+        internal bool TryRemove(TKey key, out TValue value)
+        {
+            if (Session.IsGameThread)
+                return _items.TryRemove(key, out value);
+
+            value = default(TValue);
+            RunOrQueue("remove", key, delegate
+            {
+                TValue ignored;
+                _items.TryRemove(key, out ignored);
+            });
+            return false;
+        }
+
+        internal TValue AddOrUpdate(TKey key, TValue addValue, Func<TKey, TValue, TValue> updateValueFactory)
+        {
+            if (Session.IsGameThread)
+                return _items.AddOrUpdate(key, addValue, updateValueFactory);
+
+            ThreadWork.Enqueue(_category, string.Empty, _name + " add-or-update",
+                delegate { _items.AddOrUpdate(key, addValue, updateValueFactory); });
+            TValue current;
+            return _items.TryGetValue(key, out current) ? current : addValue;
+        }
+
+        internal void Clear()
+        {
+            RunOrQueue("clear", default(TKey), delegate { _items.Clear(); });
+        }
+
+        internal void EnqueueBatch(string debugDescription, Action<ConcurrentDictionary<TKey, TValue>> apply)
+        {
+            if (apply == null) return;
+            if (Session.IsGameThread)
+            {
+                apply(_items);
+                return;
+            }
+
+            ThreadWork.Enqueue(_category, string.Empty, _name + " batch: " + debugDescription,
+                delegate { apply(_items); });
+        }
+
+        private void RunOrQueue(string operation, TKey key, Action apply)
+        {
+            if (apply == null) return;
+            if (Session.IsGameThread)
+            {
+                apply();
+                return;
+            }
+
+            var coalesceKey = _name + ":" + operation + ":" + (key == null ? string.Empty : key.ToString());
+            ThreadWork.Enqueue(_category, coalesceKey, _name + " " + operation, apply);
+        }
+    }
+}

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Threading/QueuedWrite.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Threading/QueuedWrite.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace ShipCoreFramework
+{
+    internal sealed class QueuedWrite
+    {
+        internal long Id;
+        internal int CreatedTick;
+        internal int CreatedThreadId;
+        internal string Category;
+        internal string CoalesceKey;
+        internal string DebugDescription;
+        internal Func<bool> ShouldApply;
+        internal Action Apply;
+        internal bool Cancelled;
+        internal string CancelReason;
+    }
+
+    internal struct QueuedWriteInfo
+    {
+        internal long Id;
+        internal int CreatedTick;
+        internal int CreatedThreadId;
+        internal string Category;
+        internal string CoalesceKey;
+        internal string DebugDescription;
+        internal bool Cancelled;
+        internal string CancelReason;
+    }
+}

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Threading/ThreadWork.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Threading/ThreadWork.cs
@@ -15,6 +15,7 @@ namespace ShipCoreFramework
             new ConcurrentDictionary<string, long>();
 
         private static long _nextWriteId;
+        private static int _nextBacklogLogTick;
 
         internal static long Enqueue(string category, string coalesceKey, string debugDescription, Action apply)
         {
@@ -98,6 +99,16 @@ namespace ShipCoreFramework
                 processed++;
                 if (maxOperations > 0 && processed >= maxOperations) break;
             }
+
+            if (maxOperations > 0 && PendingWrites.Count > 0 && processed >= maxOperations &&
+                Session.CurrentTick >= _nextBacklogLogTick)
+            {
+                _nextBacklogLogTick = Session.CurrentTick + 60 * 10;
+                Utils.Log("ThreadWork backlog: " + PendingWrites.Count + " queued writes remain after flushing " +
+                          processed + " operations" +
+                          (string.IsNullOrEmpty(category) ? string.Empty : " for category " + category) + ".",
+                    1, "Threading");
+            }
         }
 
         internal static QueuedWriteInfo[] SnapshotPendingWork()
@@ -172,6 +183,7 @@ namespace ShipCoreFramework
             }
 
             LatestCoalescedIds.Clear();
+            _nextBacklogLogTick = 0;
         }
 
         private static bool ShouldSkip(QueuedWrite work)

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Threading/ThreadWork.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Threading/ThreadWork.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace ShipCoreFramework
+{
+    internal static class ThreadWork
+    {
+        internal const string CountsCategory = "counts";
+        internal const string ValidationCategory = "validation";
+        internal const string StateCategory = "state";
+
+        private static readonly ConcurrentQueue<QueuedWrite> PendingWrites = new ConcurrentQueue<QueuedWrite>();
+        private static readonly ConcurrentDictionary<string, long> LatestCoalescedIds =
+            new ConcurrentDictionary<string, long>();
+
+        private static long _nextWriteId;
+
+        internal static long Enqueue(string category, string coalesceKey, string debugDescription, Action apply)
+        {
+            return Enqueue(category, coalesceKey, debugDescription, null, apply);
+        }
+
+        internal static long Enqueue(string category, string coalesceKey, string debugDescription,
+            Func<bool> shouldApply, Action apply)
+        {
+            if (apply == null) return 0;
+
+            var id = Interlocked.Increment(ref _nextWriteId);
+            var work = new QueuedWrite
+            {
+                Id = id,
+                CreatedTick = Session.CurrentTick,
+                CreatedThreadId = Thread.CurrentThread.ManagedThreadId,
+                Category = category ?? string.Empty,
+                CoalesceKey = coalesceKey ?? string.Empty,
+                DebugDescription = debugDescription ?? string.Empty,
+                ShouldApply = shouldApply,
+                Apply = apply
+            };
+
+            if (!string.IsNullOrEmpty(work.CoalesceKey))
+                LatestCoalescedIds[work.CoalesceKey] = id;
+
+            PendingWrites.Enqueue(work);
+            return id;
+        }
+
+        internal static void FlushPendingWrites()
+        {
+            FlushPendingWrites(null, 0);
+        }
+
+        internal static void FlushPendingWrites(string category)
+        {
+            FlushPendingWrites(category, 0);
+        }
+
+        internal static void FlushPendingWrites(string category, int maxOperations)
+        {
+            if (!Session.IsGameThread)
+            {
+                Utils.Log("ThreadWork.FlushPendingWrites called off game thread.", 2, "Threading");
+                return;
+            }
+
+            var processed = 0;
+            var scanned = PendingWrites.Count;
+            QueuedWrite work;
+            while (scanned > 0 && PendingWrites.TryDequeue(out work))
+            {
+                scanned--;
+                if (work == null) continue;
+
+                if (!string.IsNullOrEmpty(category) &&
+                    !string.Equals(work.Category, category, StringComparison.OrdinalIgnoreCase))
+                {
+                    PendingWrites.Enqueue(work);
+                    continue;
+                }
+
+                if (ShouldSkip(work))
+                {
+                    processed++;
+                    if (maxOperations > 0 && processed >= maxOperations) break;
+                    continue;
+                }
+
+                try
+                {
+                    work.Apply();
+                }
+                catch (Exception e)
+                {
+                    Utils.Log("Queued work failed (" + work.DebugDescription + "): " + e, 1, "Threading");
+                }
+
+                processed++;
+                if (maxOperations > 0 && processed >= maxOperations) break;
+            }
+        }
+
+        internal static QueuedWriteInfo[] SnapshotPendingWork()
+        {
+            var pending = PendingWrites.ToArray();
+            var result = new QueuedWriteInfo[pending.Length];
+            for (var i = 0; i < pending.Length; i++)
+            {
+                var work = pending[i];
+                if (work == null) continue;
+
+                result[i] = new QueuedWriteInfo
+                {
+                    Id = work.Id,
+                    CreatedTick = work.CreatedTick,
+                    CreatedThreadId = work.CreatedThreadId,
+                    Category = work.Category,
+                    CoalesceKey = work.CoalesceKey,
+                    DebugDescription = work.DebugDescription,
+                    Cancelled = work.Cancelled,
+                    CancelReason = work.CancelReason
+                };
+            }
+
+            return result;
+        }
+
+        internal static int CancelPendingWhere(Func<QueuedWriteInfo, bool> predicate, string reason)
+        {
+            if (predicate == null) return 0;
+
+            var count = 0;
+            foreach (var work in PendingWrites.ToArray())
+            {
+                if (work == null || work.Cancelled) continue;
+                var info = new QueuedWriteInfo
+                {
+                    Id = work.Id,
+                    CreatedTick = work.CreatedTick,
+                    CreatedThreadId = work.CreatedThreadId,
+                    Category = work.Category,
+                    CoalesceKey = work.CoalesceKey,
+                    DebugDescription = work.DebugDescription,
+                    Cancelled = work.Cancelled,
+                    CancelReason = work.CancelReason
+                };
+
+                if (!predicate(info)) continue;
+                work.Cancelled = true;
+                work.CancelReason = reason ?? string.Empty;
+                count++;
+            }
+
+            return count;
+        }
+
+        internal static void CancelAll(string reason)
+        {
+            foreach (var work in PendingWrites.ToArray())
+            {
+                if (work == null || work.Cancelled) continue;
+                work.Cancelled = true;
+                work.CancelReason = reason ?? string.Empty;
+            }
+        }
+
+        internal static void Clear()
+        {
+            QueuedWrite ignored;
+            while (PendingWrites.TryDequeue(out ignored))
+            {
+            }
+
+            LatestCoalescedIds.Clear();
+        }
+
+        private static bool ShouldSkip(QueuedWrite work)
+        {
+            if (work.Cancelled) return true;
+            if (Session.IsShuttingDown) return true;
+
+            if (!string.IsNullOrEmpty(work.CoalesceKey))
+            {
+                long latestId;
+                if (LatestCoalescedIds.TryGetValue(work.CoalesceKey, out latestId) && latestId != work.Id)
+                    return true;
+            }
+
+            return work.ShouldApply != null && !work.ShouldApply();
+        }
+    }
+}

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Threading/ThreadWork.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Threading/ThreadWork.cs
@@ -31,7 +31,7 @@ namespace ShipCoreFramework
             {
                 Id = id,
                 CreatedTick = Session.CurrentTick,
-                CreatedThreadId = Thread.CurrentThread.ManagedThreadId,
+                CreatedThreadId = Environment.CurrentManagedThreadId,
                 Category = category ?? string.Empty,
                 CoalesceKey = coalesceKey ?? string.Empty,
                 DebugDescription = debugDescription ?? string.Empty,

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/UI/Commands.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/UI/Commands.cs
@@ -140,8 +140,8 @@ namespace ShipCoreFramework
             var bodySort = new Dictionary<string, string>();
             if (args.Length < 3 || !CheckIfAdmin(playerId))
             {
-                Dictionary<string, int> playerVal;
-                if(PerPlayerManager.PerPlayer.TryGetValue(playerId, out playerVal))
+                Dictionary<string, int> playerVal = PerPlayerManager.GetPlayerCountsSnapshot(playerId);
+                if(playerVal.Count > 0)
                 {
                     foreach (var classCount in playerVal)
                     {
@@ -156,8 +156,10 @@ namespace ShipCoreFramework
                 
                 var faction = MyAPIGateway.Session.Factions.TryGetPlayerFaction(playerId);
                 var factionId = faction?.FactionId ?? -1;
-                Dictionary<string, int> factionVal;
-                if(factionId != -1 && PerFactionManager.PerFaction.TryGetValue(factionId, out factionVal))
+                Dictionary<string, int> factionVal = factionId != -1
+                    ? PerFactionManager.GetFactionCountsSnapshot(factionId)
+                    : new Dictionary<string, int>();
+                if(factionVal.Count > 0)
                 {
                     foreach (var classCount in factionVal)
                     {
@@ -179,19 +181,16 @@ namespace ShipCoreFramework
                 var sub = args[1].ToLower();
                 switch (sub)
                 {
-                    /*
-                    case "update":
-                        PerPlayerManager.PerPlayer=PerPlayerManager.GetDefaultPlayerGridsSet();
-                        PerFactionManager.PerFaction=PerFactionManager.GetDefaultFactionGridsSet();
-                        break;*/
                     case "faction":
                         goto case "f";
                     case "f":
                         if (!long.TryParse(args[2], out playerId)) return;
                         var faction = MyAPIGateway.Session.Factions.TryGetPlayerFaction(playerId);
                         var factionId = faction?.FactionId ?? -1;
-                        Dictionary<string, int> factionVal;
-                        if(factionId != -1 && PerFactionManager.PerFaction.TryGetValue(factionId, out factionVal))
+                        Dictionary<string, int> factionVal = factionId != -1
+                            ? PerFactionManager.GetFactionCountsSnapshot(factionId)
+                            : new Dictionary<string, int>();
+                        if(factionVal.Count > 0)
                         {
                             foreach (var classCount in factionVal)
                             {
@@ -208,8 +207,8 @@ namespace ShipCoreFramework
                         goto case "p";
                     case "p":
                         if (!long.TryParse(args[2], out playerId)) return;
-                        Dictionary<string, int> playerVal;
-                        if(PerPlayerManager.PerPlayer.TryGetValue(playerId, out playerVal))
+                        Dictionary<string, int> playerVal = PerPlayerManager.GetPlayerCountsSnapshot(playerId);
+                        if(playerVal.Count > 0)
                         {
                             foreach (var classCount in playerVal)
                             {

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/UI/Commands.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/UI/Commands.cs
@@ -775,11 +775,13 @@ namespace ShipCoreFramework
                 body += $"    Max Boost Speed: {speedmods.MaxBoost:F2}\n";
                 if (Session.Config.FrictionSpeedValueMode == FrictionSpeedValueMode.Modifier)
                 {
-                    var minMod = groupComponent.MinimumFrictionSpeedModifierOverride >= 0f
-                        ? groupComponent.MinimumFrictionSpeedModifierOverride
+                    var minModOverride = groupComponent.GetMinimumFrictionSpeedModifierOverride();
+                    var maxModOverride = groupComponent.GetMaximumFrictionSpeedModifierOverride();
+                    var minMod = minModOverride >= 0f
+                        ? minModOverride
                         : speedmods.MinimumFrictionSpeedModifier;
-                    var maxMod = groupComponent.MaximumFrictionSpeedModifierOverride >= 0f
-                        ? groupComponent.MaximumFrictionSpeedModifierOverride
+                    var maxMod = maxModOverride >= 0f
+                        ? maxModOverride
                         : speedmods.MaximumFrictionSpeedModifier;
 
                     var minReal = Session.Config.MaxPossibleSpeedMetersPerSecond * minMod;
@@ -789,11 +791,13 @@ namespace ShipCoreFramework
                 }
                 else
                 {
-                    var minAbs = groupComponent.MinimumFrictionSpeedAbsoluteOverride >= 0f
-                        ? groupComponent.MinimumFrictionSpeedAbsoluteOverride
+                    var minAbsOverride = groupComponent.GetMinimumFrictionSpeedAbsoluteOverride();
+                    var maxAbsOverride = groupComponent.GetMaximumFrictionSpeedAbsoluteOverride();
+                    var minAbs = minAbsOverride >= 0f
+                        ? minAbsOverride
                         : speedmods.MinimumFrictionSpeedAbsolute;
-                    var maxAbs = groupComponent.MaximumFrictionSpeedAbsoluteOverride >= 0f
-                        ? groupComponent.MaximumFrictionSpeedAbsoluteOverride
+                    var maxAbs = maxAbsOverride >= 0f
+                        ? maxAbsOverride
                         : speedmods.MaximumFrictionSpeedAbsolute;
 
                     body += $"    Min Friction:    {minAbs:F1} m/s\n";
@@ -803,9 +807,18 @@ namespace ShipCoreFramework
                 body += $"    Boost Duration:  {speedmods.BoostDuration:F2}\n";
                 body += $"    Boost Cooldown:  {speedmods.BoostCoolDown:F2}\n";
             }
-            body += $"    Base Limit:      {groupComponent.BaseSpeedLimitMetersPerSecond:F1} m/s\n";
-            var effectiveSpeedLine = $"    Effective Limit: {groupComponent.EffectiveSpeedLimitMetersPerSecond:F1} m/s";
-            var sourceGridId = groupComponent.SpeedSourceGroupGridId;
+            float baseSpeedLimit;
+            float effectiveSpeedLimit;
+            long sourceGridId;
+            lock (groupComponent.SpeedStateLock)
+            {
+                baseSpeedLimit = groupComponent.BaseSpeedLimitMetersPerSecond;
+                effectiveSpeedLimit = groupComponent.EffectiveSpeedLimitMetersPerSecond;
+                sourceGridId = groupComponent.SpeedSourceGroupGridId;
+            }
+
+            body += $"    Base Limit:      {baseSpeedLimit:F1} m/s\n";
+            var effectiveSpeedLine = $"    Effective Limit: {effectiveSpeedLimit:F1} m/s";
             if (sourceGridId != 0 && !groupComponent.GridDictionary.Keys.Any(g => g != null && g.EntityId == sourceGridId))
             {
                 var sourceGrid = MyAPIGateway.Entities.GetEntityById(sourceGridId) as IMyCubeGrid;

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/UI/CoreTypeLCDScript.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/UI/CoreTypeLCDScript.cs
@@ -209,8 +209,13 @@ namespace ShipCoreFramework
             }
             
             SpeedEnforcement.RefreshSpeedState(GroupComponent);
-            var speed = GroupComponent.EffectiveSpeedLimitMetersPerSecond;
-            var speedSourceGridId = GroupComponent.SpeedSourceGroupGridId;
+            float speed;
+            long speedSourceGridId;
+            lock (GroupComponent.SpeedStateLock)
+            {
+                speed = GroupComponent.EffectiveSpeedLimitMetersPerSecond;
+                speedSourceGridId = GroupComponent.SpeedSourceGroupGridId;
+            }
             var speedLabel = speedSourceGridId != 0 && !GroupComponent.GridDictionary.Keys.Any(g => g != null && g.EntityId == speedSourceGridId)
                 ? "Max Speed*: "
                 : "Max Speed: ";

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,6 +6,7 @@
   <title>SE Ship Core Docs</title>
 </head>
 <body>
-  <p>Redirecting to <a href="./configurator/">configurator</a>…</p>
+  <p>Redirecting to <a href="./configurator/">configurator</a>.</p>
+  <p>Design notes: <a href="./threading-plan.md">threading plan</a>.</p>
 </body>
 </html>

--- a/docs/threading-plan.md
+++ b/docs/threading-plan.md
@@ -243,6 +243,13 @@ Debug behavior:
 - Add cancellation and coalescing by group id.
 - Ensure unload cancels all pending work.
 
+### Phase 3.5: Live Collection Safety
+
+- Use concurrent containers for SCF-owned state that can be enumerated by background work while grid, block, or group callbacks mutate it.
+- Keep explicit locks on aggregate buckets and connected-group sets where the protected data is more than a single dictionary entry.
+- Prefer non-throwing mutations (`TryAdd`, `TryRemove`, `GetOrAdd`) for callback-driven state so duplicate or out-of-order game events become no-ops instead of hard crashes.
+- Treat this as crash hardening, not a consistency barrier. Rebuild/apply phases such as limit recalculation may still need a group-level write barrier if exact snapshots are required.
+
 ### Phase 4: SE API Audit
 
 Audit background paths for calls that touch:

--- a/docs/threading-plan.md
+++ b/docs/threading-plan.md
@@ -1,0 +1,285 @@
+# SCF Threading Plan
+
+This document captures the plan for a full multithreading pass in Ship Core Framework. The first piece of groundwork is a game-thread write wrapper for shared state, plus an inspectable queue for work that must be applied later on the game thread.
+
+## Goals
+
+- Keep reads safe from background workers.
+- Keep writes deterministic by applying them on the game thread.
+- Make queued work visible for debugging and niche interception.
+- Avoid live `Dictionary` enumeration while another thread may mutate it.
+- Separate collection safety from Space Engineers API safety.
+- Give Nexus sync, limit managers, speed enforcement, and delayed validations a consistent threading model.
+
+## Non-Goals
+
+- The wrapper must not make SE game objects safe to touch off-thread. Blocks, grids, physics, definitions, ownership changes, upgrade links, removals, and terminal properties still need game-thread access.
+- The wrapper should not hide expensive game-thread work. Large batches must stay visible and measurable.
+- The wrapper should not expose the internal mutable collection to callers.
+
+## Current Risk Classes
+
+The diff since `3.6.0` highlighted two examples that this pass should prevent:
+
+- Background validation can call routines that inspect upgrade attachments and apply block modifiers.
+- Speed source selection can call grid mass APIs from a background worker.
+
+More generally, SCF has these recurring risks:
+
+- Normal dictionaries are enumerated for snapshots while other paths can mutate counts.
+- Delayed work can become stale when a group splits, merges, closes, deactivates, or changes core.
+- Counter updates can be half-applied if remove/add operations are not batched.
+- Nexus snapshots can observe intermediate state.
+- Unload can leave queued work targeting closed entities.
+
+## Wrapper Model
+
+Use a game-thread write wrapper around a thread-safe backing store.
+
+Recommended backing store:
+
+```csharp
+ConcurrentDictionary<TKey, TValue>
+```
+
+Reads may happen from any thread. Writes are applied only on the game thread. If a caller requests a write from a background thread, the wrapper queues the write for the next game-thread flush.
+
+The wrapper should support:
+
+- `TryGetValue`
+- `ContainsKey`
+- `GetOrDefault`
+- `ToArraySnapshot`
+- `ValuesSnapshot`
+- `Set`
+- `Remove`
+- `AddOrUpdate`
+- `Increment`
+- `EnqueueBatch`
+- `FlushPendingWrites`
+- `SnapshotPendingWork`
+- `CancelPendingWhere`
+
+Avoid nested mutable dictionaries. A wrapper around `Dictionary<long, Dictionary<string, int>>` still leaves the inner dictionaries unsafe. Prefer flattened keys:
+
+```csharp
+internal struct CoreCountKey
+{
+    internal long OwnerOrFactionId;
+    internal string CoreType;
+}
+```
+
+Then store counts as:
+
+```csharp
+GameThreadWriteDictionary<CoreCountKey, int>
+```
+
+Manifest group counts can use:
+
+```csharp
+GameThreadWriteDictionary<string, int>
+```
+
+## Queued Work
+
+Queued work should be structured data, not raw anonymous actions. This makes it inspectable, cancellable, and coalescible.
+
+API sketch:
+
+```csharp
+internal sealed class QueuedWrite
+{
+    internal long Id;
+    internal int CreatedTick;
+    internal int CreatedThreadId;
+    internal string Category;
+    internal string CoalesceKey;
+    internal string DebugDescription;
+    internal Func<bool> ShouldApply;
+    internal Action Apply;
+    internal bool Cancelled;
+    internal string CancelReason;
+}
+```
+
+The wrapper can expose a copy for diagnostics:
+
+```csharp
+internal QueuedWriteInfo[] SnapshotPendingWork()
+```
+
+`QueuedWriteInfo` should be a safe data object that does not expose the original `Action`.
+
+## Interception Points
+
+Interception is needed for real SCF corner cases, not just debugging.
+
+Before apply:
+
+- Drop all work when `Session.IsShuttingDown`.
+- Drop group work when the group was cleaned or no longer matches the expected group id.
+- Drop grid or block work when the entity is closed, marked for close, or no longer belongs to the expected group.
+- Drop config-sensitive work when the config version changed.
+- Drop validation work if a newer validation for the same group replaced it.
+
+Coalescing:
+
+- Keep only the latest `Set` for a given count key.
+- Merge repeated `Increment` operations for the same key when ordering does not matter.
+- Replace delayed validations for the same group with the latest validation.
+
+Batch boundaries:
+
+- Ownership transfer counters should be one batch.
+- Core activation and reset counter changes should be one batch.
+- Nexus snapshot preparation should run after a flush barrier.
+
+## Flush Lifecycle
+
+The game-thread flush should happen in `UpdateAfterSimulation` before the background worker starts:
+
+```csharp
+ThreadWork.FlushPendingWrites();
+
+MyAPIGateway.Parallel.StartBackground(() =>
+{
+    // background reads and background-safe calculations only
+});
+```
+
+Some systems may need an additional flush before Nexus snapshots:
+
+```csharp
+ThreadWork.FlushPendingWrites(ThreadWorkCategory.Counts);
+LimitsNexusSync.RunPeriodicSnapshotTick();
+```
+
+Flush must have a time or operation budget if batches can become large. If the budget is reached, leave the remaining work queued and log the backlog at a throttled rate.
+
+## Game-Thread Detection
+
+Capture the game-thread id during session startup:
+
+```csharp
+Session.GameThreadId = Thread.CurrentThread.ManagedThreadId;
+```
+
+Expose:
+
+```csharp
+internal static bool IsGameThread
+{
+    get { return Thread.CurrentThread.ManagedThreadId == GameThreadId; }
+}
+```
+
+Debug behavior:
+
+- Immediate write APIs can log when called off-thread.
+- Strict mode can throw on off-thread immediate writes during development.
+- Queue APIs should be allowed from any thread.
+
+## Wrapper Usage Rules
+
+- Never return the backing `ConcurrentDictionary`.
+- Never return live mutable values.
+- Snapshot before enumeration.
+- Do not enqueue work that captures live blocks or grids unless `ShouldApply` revalidates them on the game thread.
+- Prefer ids and stable keys over captured entity references.
+- Prefer `CoalesceKey` for repeated delayed work.
+- Keep batches small and named.
+
+## First Migration Targets
+
+1. `PerPlayerManager`
+   - Replace nested dictionaries with flattened count keys.
+   - Make count reads snapshot-safe.
+   - Batch owner/core count transitions.
+
+2. `PerFactionManager`
+   - Same flattened count model.
+   - Make faction removal a batch.
+   - Keep Nexus broadcasts after local write flush.
+
+3. `PerManifestGroupManager`
+   - Wrap manifest group counts.
+   - Snapshot before Nexus build.
+
+4. `LimitsNexusSync`
+   - Build snapshots from snapshot arrays only.
+   - Avoid reading live mutable count structures.
+   - Consider a flush barrier before periodic snapshot.
+
+5. Delayed limit validation
+   - Queue the validation as game-thread work.
+   - Use a group validation `CoalesceKey`.
+   - Drop stale work if the group closes or the validation generation changed.
+
+6. Speed source selection
+   - Remove direct mass API calls from background ranking.
+   - Cache group dry mass on the game thread, or use a background-safe ranking input.
+
+## Full Threading Pass Phases
+
+### Phase 1: Instrumentation
+
+- Add game-thread id capture.
+- Add `Session.IsGameThread`.
+- Add throttled logging for off-thread SE API sensitive paths.
+- Add queue backlog diagnostics.
+
+### Phase 2: Shared Count State
+
+- Add the wrapper.
+- Migrate player, faction, and manifest counters.
+- Convert Nexus snapshot building to snapshot arrays.
+- Add batch writes for ownership and core transitions.
+
+### Phase 3: Delayed Work
+
+- Move delayed validation apply work to the game-thread queue.
+- Add cancellation and coalescing by group id.
+- Ensure unload cancels all pending work.
+
+### Phase 4: SE API Audit
+
+Audit background paths for calls that touch:
+
+- `MyCubeGrid`
+- `IMySlimBlock`
+- `IMyCubeBlock`
+- terminal properties
+- physics and mass APIs
+- upgrade module attachment APIs
+- ownership APIs
+- block removal, damage, refund, or enable state
+
+Move unsafe calls to game-thread queued work, or replace them with cached data collected on the game thread.
+
+### Phase 5: Snapshot Caches
+
+For background speed, limits, and Nexus work, maintain explicit game-thread caches:
+
+- group block count
+- PCU
+- dry/wet mass
+- representative grid id
+- active core subtype
+- speed override mode and priority
+- no-core/core state
+
+Background workers should consume these caches, not live SE objects.
+
+## Open Questions
+
+- Should strict off-thread write violations throw in debug builds or only log?
+- What is the max queued operation budget per tick?
+- Do Nexus snapshots require a hard flush barrier every time, or only before periodic snapshots?
+- Should queued work be exposed through chat/admin debug commands?
+- Should batch failures be all-or-nothing, or should each operation validate independently?
+
+## Working Principle
+
+Collections can be made thread-safe. SE game objects cannot. The wrapper protects SCF state, while the threading pass must still move every game-object mutation and sensitive read back to the game thread or a game-thread-built cache.

--- a/docs/threading-plan.md
+++ b/docs/threading-plan.md
@@ -246,6 +246,8 @@ Debug behavior:
 ### Phase 3.5: Live Collection Safety
 
 - Use concurrent containers for SCF-owned state that can be enumerated by background work while grid, block, or group callbacks mutate it.
+- Use `GameThreadWriteDictionary` for authoritative cross-system state when delayed game-thread visibility is acceptable.
+- Use a raw concurrent container for construction-local indexes that must be written and read during the same background initialization pass.
 - Keep explicit locks on aggregate buckets and connected-group sets where the protected data is more than a single dictionary entry.
 - Prefer non-throwing mutations (`TryAdd`, `TryRemove`, `GetOrAdd`) for callback-driven state so duplicate or out-of-order game events become no-ops instead of hard crashes.
 - Treat this as crash hardening, not a consistency barrier. Rebuild/apply phases such as limit recalculation may still need a group-level write barrier if exact snapshots are required.
@@ -278,6 +280,12 @@ For background speed, limits, and Nexus work, maintain explicit game-thread cach
 - no-core/core state
 
 Background workers should consume these caches, not live SE objects.
+
+Related timer and speed fields should be updated through a lock or snapshot helper when multiple values represent one state transition, such as boost enabled, remaining duration, cooldown, and post-boost ramp state.
+
+No-fly zone checks should use cached grid positions, names, and owner ids for background distance tests. Any block punishment must be queued back to game-thread work and revalidated against the live grid before applying.
+
+API and UI reads of speed override/effective state should use the same lock or helper methods as the background speed worker. Group lookup by grid id should prefer cached group grid ids and use live grid-group APIs only as a game-thread fallback.
 
 ## Open Questions
 


### PR DESCRIPTION
This pull request introduces several improvements to thread safety and API consistency in the `ShipCoreFramework`. The main focus is on ensuring that operations which interact with game objects or require the game thread are properly scheduled, and on standardizing how friction and speed settings are accessed and modified through the API. It also adds a project configuration tweak to control assembly version attributes.

**Thread safety and event handling improvements:**

* Added thread-aware scheduling for core and beacon block event attachment and state persistence, ensuring these operations occur on the game thread when required. This reduces the risk of race conditions or invalid access from background threads. (`CoreComponent.Events.cs`, `CoreComponent.cs`, `BeaconComponent.cs`) [[1]](diffhunk://#diff-f7132adc9d2aa630be465a2286594a8dfa84baaa929ad1dc4178f629b6f50652R9-R41) [[2]](diffhunk://#diff-c057e9748a29605feb39d08c4f8ba0a95446d2a98b057e36775e90c101fb8d39R23-R44) [[3]](diffhunk://#diff-225d0d4b7ebbb89e59ed7b090ed4017210fd0c595631000d30cb5e9c4d9ab7c4R32-R48)
* Introduced an `_eventsAttached` flag to prevent duplicate event handler registration and ensure proper detachment. (`CoreComponent.cs`, `CoreComponent.Events.cs`) [[1]](diffhunk://#diff-c057e9748a29605feb39d08c4f8ba0a95446d2a98b057e36775e90c101fb8d39R9) [[2]](diffhunk://#diff-f7132adc9d2aa630be465a2286594a8dfa84baaa929ad1dc4178f629b6f50652R9-R41)

**API consistency and encapsulation:**

* Refactored all direct accesses and assignments to friction and speed override fields in `GroupComponent` to use corresponding getter and setter methods, improving encapsulation and maintainability. (`ModAPI.cs`) [[1]](diffhunk://#diff-75fb5412ffbb75e1749271580b7093792668d9ea8aa574d33edd848871a0767dL595-R589) [[2]](diffhunk://#diff-75fb5412ffbb75e1749271580b7093792668d9ea8aa574d33edd848871a0767dL613-R607) [[3]](diffhunk://#diff-75fb5412ffbb75e1749271580b7093792668d9ea8aa574d33edd848871a0767dL634-R628) [[4]](diffhunk://#diff-75fb5412ffbb75e1749271580b7093792668d9ea8aa574d33edd848871a0767dL654-R648) [[5]](diffhunk://#diff-75fb5412ffbb75e1749271580b7093792668d9ea8aa574d33edd848871a0767dL672-R666) [[6]](diffhunk://#diff-75fb5412ffbb75e1749271580b7093792668d9ea8aa574d33edd848871a0767dL692-R690) [[7]](diffhunk://#diff-75fb5412ffbb75e1749271580b7093792668d9ea8aa574d33edd848871a0767dL711-R709) [[8]](diffhunk://#diff-75fb5412ffbb75e1749271580b7093792668d9ea8aa574d33edd848871a0767dL725-R719) [[9]](diffhunk://#diff-75fb5412ffbb75e1749271580b7093792668d9ea8aa574d33edd848871a0767dL734-R728) [[10]](diffhunk://#diff-75fb5412ffbb75e1749271580b7093792668d9ea8aa574d33edd848871a0767dL748-R746) [[11]](diffhunk://#diff-75fb5412ffbb75e1749271580b7093792668d9ea8aa574d33edd848871a0767dL767-R765) [[12]](diffhunk://#diff-75fb5412ffbb75e1749271580b7093792668d9ea8aa574d33edd848871a0767dL781-R775) [[13]](diffhunk://#diff-75fb5412ffbb75e1749271580b7093792668d9ea8aa574d33edd848871a0767dL790-R784)
* Updated `TryGetGroupComponent` to first check a utility method for resolving group components, and to be thread-aware, improving robustness when called from different threads. (`ModAPI.cs`)
* Simplified logic in API methods such as `GetSpeedModifiers` and `IsBoostActive` to use `TryGetGroupComponent`, removing redundant entity and group resolution code. (`ModAPI.cs`) [[1]](diffhunk://#diff-75fb5412ffbb75e1749271580b7093792668d9ea8aa574d33edd848871a0767dL554-R557) [[2]](diffhunk://#diff-75fb5412ffbb75e1749271580b7093792668d9ea8aa574d33edd848871a0767dL1535-R1545)

**Project configuration:**

* Disabled automatic generation of the assembly informational version attribute in the project file to allow for custom versioning. (`ShipCoreFramework.csproj`)

**Other minor changes:**

* Removed a redundant upgrade value assignment in `CoreComponent` initialization. (`CoreComponent.Init.cs`)
* Updated event attachment logic in `CoreComponent` initialization to use the new thread-aware method. (`CoreComponent.Init.cs`) [[1]](diffhunk://#diff-d2067b47f5d28ac1a19ad8a47307d6aeeb1e1deaf5c87bed3199fcbce05a91ccL111-R110) [[2]](diffhunk://#diff-d2067b47f5d28ac1a19ad8a47307d6aeeb1e1deaf5c87bed3199fcbce05a91ccL123-R120)