### PR TITLE
fix(commands): correct GridDictionary key type and mission screen subtitle spacing

### DIFF
--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Client/UI/Commands.Presentation.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Client/UI/Commands.Presentation.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using Sandbox.Game;
+using Sandbox.Game.Entities;
 using Sandbox.ModAPI;
 using VRage.Game.ModAPI;
 using VRageMath;
@@ -66,7 +67,7 @@ namespace ShipCoreFramework
 
             MyAPIGateway.Utilities.ShowMissionScreen(
                 "ShipCore Framework",
-                "/core listnoflyzones",
+                "/core listnoflyzones ",
                 "No-Fly Zones",
                 body,
                 null,
@@ -84,7 +85,7 @@ namespace ShipCoreFramework
             string body = GetCoreInfo(targetGrid, shipCore, groupComponent);
             MyAPIGateway.Utilities.ShowMissionScreen(
                 "Ship Core Framework",
-                $"Ship Class Limits - {targetGrid.CustomName}",
+                $"Ship Class Limits - {targetGrid.CustomName} ",
                 "Block Limits & Usage",
                 body,
                 null,
@@ -101,7 +102,7 @@ namespace ShipCoreFramework
             string body = GetCoreLimits(targetGrid, groupComponent.ShipCore, groupComponent);
             MyAPIGateway.Utilities.ShowMissionScreen(
                 "Ship Core Framework",
-                $"Ship Class Limits - {targetGrid.CustomName}",
+                $"Ship Class Limits - {targetGrid.CustomName} ",
                 "Block Limits & Usage",
                 body,
                 null,
@@ -185,7 +186,7 @@ namespace ShipCoreFramework
                 Dictionary<string, Dictionary<double, int>> usage =
                     new Dictionary<string, Dictionary<double, int>>(StringComparer.OrdinalIgnoreCase);
 
-                foreach (KeyValuePair<IMyCubeGrid, GridComponent> gridEntry in groupComponent.GridDictionary)
+                foreach (KeyValuePair<MyCubeGrid, GridComponent> gridEntry in groupComponent.GridDictionary)
                 {
                     GridComponent gridComponent = gridEntry.Value;
                     if (gridComponent == null) continue;
@@ -609,7 +610,7 @@ Raycasts from crosshairs to find a grid and displays per-limit block usage by di
 
             MyAPIGateway.Utilities.ShowMissionScreen(
                 "ShipCore Framework",
-                "/core help",
+                "/core help ",
                 "Command Reference",
                 body,
                 null,


### PR DESCRIPTION
## Compile fix

`GetCoreLimits` iterated the group's grids as `KeyValuePair<IMyCubeGrid, GridComponent>`, but `GroupComponent.GridDictionary` is a `ConcurrentDictionary<MyCubeGrid, GridComponent>`. `KeyValuePair<,>` is not covariant, so there is no conversion between the two and the mod failed to compile on world load:

```
Commands.Presentation.cs(188,16): Error: Cannot convert type
'KeyValuePair<Sandbox.Game.Entities.MyCubeGrid, ShipCoreFramework.GridComponent>' to
'KeyValuePair<VRage.Game.ModAPI.IMyCubeGrid, ShipCoreFramework.GridComponent>'
```

Changed the loop variable to `MyCubeGrid` and added the `Sandbox.Game.Entities` using.

## Mission screen subtitle spacing

`MyGuiScreenText` builds the subtitle by direct concatenation:

```csharp
m_currentObjectiveLabel.Text = m_currentObjectivePrefix + m_currentObjective;
```

No separator is inserted, so the prefix has to carry its own — SE's default prefix is `"Current objective: "`, and `Commands.Inventory` already ends its prefix with `\n`. The four screens in `Commands.Presentation` did not, so they rendered as:

- `Ship Class Limits - <grid>Block Limits & Usage` (`/core limits`, `/core info`)
- `/core listnoflyzonesNo-Fly Zones`
- `/core helpCommand Reference`

Added a trailing space to each prefix.

## Testing

Tested in-game. The mod compiles and the subtitles render as expected.
