### PR TITLE
Range filter runtime state by SyncDistance, serialize once per packet, guard null core blocks

### DIFF
--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Client/UI/CoreTerminalControls.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Client/UI/CoreTerminalControls.cs
@@ -189,8 +189,8 @@ namespace ShipCoreFramework
             }
 
             var group = block.GetGroupComponent();
-            return group?.MainCoreComponent != null &&
-                   group.MainCoreComponent.CoreBlock.EntityId == block.EntityId;
+            var mainCore = group?.MainCoreComponent;
+            return mainCore?.CoreBlock?.EntityId == block.EntityId;
         }
     }
 }

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Server/Components/GroupComponent.Lifecycle.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Server/Components/GroupComponent.Lifecycle.cs
@@ -246,12 +246,16 @@ namespace ShipCoreFramework
             old.IsMainCore = false;
 
             var type = ShipCore.SubtypeId;
-            var grid = old.CoreBlock.CubeGrid;
-            Utils.Log($"Reset: Resetting logic for {grid.CustomName}!", 2);
+            // CoreBlock can already be gone when the core is reset because its block was
+            // destroyed; the reset itself must still run, so only the logging degrades.
+            var coreBlock = old.CoreBlock;
+            var grid = coreBlock?.CubeGrid;
+            Utils.Log($"Reset: Resetting logic for {grid?.CustomName ?? "<unknown grid>"}!", 2);
 
             UnregisterCoreLimitTracking();
 
-            ModAPI.BroadcastCoreDeactivated(GetRepresentativeGridId(), type, old.CoreBlock.CustomName);
+            ModAPI.BroadcastCoreDeactivated(GetRepresentativeGridId(), type,
+                coreBlock?.CustomName ?? string.Empty);
 
             MainCoreComponent = null;
             InvalidateGameThreadStateCache(true);

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Server/Components/GroupComponent.Snapshot.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Server/Components/GroupComponent.Snapshot.cs
@@ -54,7 +54,10 @@ namespace ShipCoreFramework
             var speedModifiers = SpeedModifiers;
             var ownerId = OwnerId;
             var faction = OwningFaction;
-            var subtypeId = MainCoreComponent == null ? string.Empty : MainCoreComponent.SubtypeId;
+            // Read the field once: failover can null or swap it while this snapshot is being
+            // built, and every consumer below must see the same core.
+            var mainCore = MainCoreComponent;
+            var subtypeId = mainCore == null ? string.Empty : mainCore.SubtypeId;
             var countSubtypeId = ShipCore == null ? subtypeId : ShipCore.SubtypeId;
             var factionPlayerCount = PerFactionManager.GetFactionPlayerCount(faction, ownerId);
             var effectiveFactionCoreLimit = PerFactionManager.GetEffectiveFactionCoreLimit(ShipCore,
@@ -119,7 +122,7 @@ namespace ShipCoreFramework
                 Revision = revision,
                 GridIds = gridIds.ToArray(),
                 CoreSubtypeId = subtypeId,
-                MainCoreBlockId = MainCoreComponent == null ? 0L : MainCoreComponent.CoreBlock.EntityId,
+                MainCoreBlockId = mainCore?.CoreBlock?.EntityId ?? 0L,
                 CoreCount = CoreDictionary.Count,
                 DirectionReferenceBlockId = directionReference?.EntityId ?? 0L,
                 OwnerId = ownerId,

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Server/Utilities/Utils.Notifications.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Server/Utilities/Utils.Notifications.cs
@@ -34,14 +34,17 @@ namespace ShipCoreFramework
                         LogTooltip = tooltip
                     };
 
+                    var admins = new List<ulong>();
                     foreach (var player in players)
                     {
                         if (player == null || player.SteamUserId == 0 || player.SteamUserId == localSteamId) continue;
                         if (player.PromoteLevel != MyPromoteLevel.Admin &&
                             player.PromoteLevel != MyPromoteLevel.Owner) continue;
 
-                        Session.Networking.SendToPlayer(packet, player.SteamUserId);
+                        admins.Add(player.SteamUserId);
                     }
+
+                    Session.Networking.SendToPlayers(packet, admins);
                 });
             }
             catch
@@ -69,14 +72,17 @@ namespace ShipCoreFramework
                     MyAPIGateway.Players.GetPlayers(players);
                     double range = Session.Config.CombatLoggingBroadcastRangeMeters;
                     double rangeSquared = range * range;
+                    var inRange = new List<ulong>();
                     foreach (var player in players)
                     {
                         if (player == null || player.SteamUserId == 0) continue;
                         if (combatLogPosition.HasValue &&
                             Vector3D.DistanceSquared(player.GetPosition(), combatLogPosition.Value) > rangeSquared)
                             continue;
-                        Session.Networking.SendToPlayer(new PacketNotify(msg, disappearTime, font), player.SteamUserId);
+                        inRange.Add(player.SteamUserId);
                     }
+
+                    Session.Networking.SendToPlayers(new PacketNotify(msg, disappearTime, font), inRange);
                 }
                 else
                 {

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Session/Server/Session.RuntimeStatePublisher.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Session/Server/Session.RuntimeStatePublisher.cs
@@ -11,6 +11,9 @@ namespace ShipCoreFramework
         private const int RuntimeStatePacketTargetBytes = Networking.MaxPacketBytes - 64 * 1024;
         private const int RuntimeStateSyncIntervalTicks = 120;
         private const int RuntimeStateRequestCooldownTicks = 300;
+        // Scanning every group for liveness is O(groups + grids); at 60Hz that is pure overhead.
+        // 120 is a multiple of this, so the full-snapshot tick always includes a fresh scan.
+        private const int RuntimeStateRemovalScanIntervalTicks = 30;
         private static int _runtimeStateSequence;
         private static int _runtimeStateRevision;
         private static readonly ConcurrentDictionary<GroupComponent, byte> RuntimeStateDirty =
@@ -25,7 +28,7 @@ namespace ShipCoreFramework
         private void RunRuntimeStateSyncTick()
         {
             if (!IsServer || !MpActive) return;
-            QueueRemovedRuntimeStates();
+            if (CurrentTick % RuntimeStateRemovalScanIntervalTicks == 0) QueueRemovedRuntimeStates();
             var fullSnapshot = CurrentTick % RuntimeStateSyncIntervalTicks == 0;
             if (!fullSnapshot && RuntimeStateDirty.IsEmpty) return;
 
@@ -49,15 +52,11 @@ namespace ShipCoreFramework
 
             if (fullSnapshot)
             {
-                var fullPackets = BuildRuntimeStatePackets();
-                for (var i = 0; i < recipients.Count; i++)
-                    SendRuntimeStatePacketsTo(fullPackets, recipients[i]);
+                SendRuntimeStatePacketsToAll(BuildRuntimeStatePackets(), recipients);
                 return;
             }
 
-            var deltaPackets = BuildRuntimeStateDeltaPackets(dirtyGroups);
-            for (var i = 0; i < recipients.Count; i++)
-                SendRuntimeStateDeltaPacketsTo(deltaPackets, recipients[i]);
+            SendRuntimeStateDeltaPacketsToAll(BuildRuntimeStateDeltaPackets(dirtyGroups), recipients);
         }
         internal static void SendRuntimeStateTo(ulong steamId)
         {
@@ -289,10 +288,21 @@ namespace ShipCoreFramework
                 Networking.SendToPlayer(packets[i], steamId);
         }
 
-        private static void SendRuntimeStateDeltaPacketsTo(PacketRuntimeStateDelta[] packets, ulong steamId)
+        // Loop packets on the outside and recipients on the inside: each packet is serialized
+        // once and the buffer is reused, instead of re-encoding it per player.
+        private static void SendRuntimeStatePacketsToAll(PacketRuntimeState[] packets, List<ulong> recipients)
         {
-            if (packets == null || Networking == null) return;
-            for (var i = 0; i < packets.Length; i++) Networking.SendToPlayer(packets[i], steamId);
+            if (packets == null || recipients == null || Networking == null) return;
+            for (var i = 0; i < packets.Length; i++)
+                Networking.SendToPlayers(packets[i], recipients);
+        }
+
+        private static void SendRuntimeStateDeltaPacketsToAll(PacketRuntimeStateDelta[] packets,
+            List<ulong> recipients)
+        {
+            if (packets == null || recipients == null || Networking == null) return;
+            for (var i = 0; i < packets.Length; i++)
+                Networking.SendToPlayers(packets[i], recipients);
         }
 
         private sealed class RuntimeStateIdentity

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Session/Server/Session.RuntimeStatePublisher.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Session/Server/Session.RuntimeStatePublisher.cs
@@ -15,9 +15,10 @@ namespace ShipCoreFramework
         // Scanning every group for liveness is O(groups + grids); at 60Hz that is pure overhead.
         // 120 is a multiple of this, so the full-snapshot tick always includes a fresh scan.
         private const int RuntimeStateRemovalScanIntervalTicks = 30;
-        // Used only when session settings are unavailable. Never fall back to "no filtering",
-        // because that would publish the whole world to every client.
-        private const double RuntimeStateFallbackRangeMeters = 15000d;
+        // Used only when session settings are unavailable, and matches the stock SyncDistance
+        // default. Never fall back to "no filtering", because that would publish the whole
+        // world to every client.
+        private const double RuntimeStateFallbackRangeMeters = 3000d;
         private static int _runtimeStateSequence;
         private static int _runtimeStateRevision;
         private static readonly ConcurrentDictionary<GroupComponent, byte> RuntimeStateDirty =
@@ -165,13 +166,14 @@ namespace ShipCoreFramework
         // ---- relevance ----------------------------------------------------------------
 
         /// <summary>
-        /// Squared broadcast radius. Clients are only told about groups they could observe
-        /// in game, so runtime state cannot be used to see past render range.
+        /// Squared broadcast radius, bounded by SyncDistance. That is the radius at which the
+        /// engine replicates grid entities to a client, so beyond it the client has no entity
+        /// to attach state to and could not observe the grid by any means.
         /// </summary>
         private static double GetRuntimeStateRangeSquared()
         {
             var settings = MyAPIGateway.Session == null ? null : MyAPIGateway.Session.SessionSettings;
-            double range = settings == null ? 0 : settings.ViewDistance;
+            double range = settings == null ? 0 : settings.SyncDistance;
             if (range <= 0d) range = RuntimeStateFallbackRangeMeters;
             return range * range;
         }

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Session/Server/Session.RuntimeStatePublisher.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Session/Server/Session.RuntimeStatePublisher.cs
@@ -28,6 +28,13 @@ namespace ShipCoreFramework
             new Dictionary<ulong, int>();
         private static readonly Dictionary<ulong, int> ConfigRequestTicks =
             new Dictionary<ulong, int>();
+        // Reused scratch buffers. Everything here runs on the game thread, and the delta path
+        // runs every tick, so per-tick allocation is worth avoiding.
+        private static readonly List<IMyPlayer> RuntimeStatePlayerBuffer = new List<IMyPlayer>();
+        private static readonly List<RuntimeStateRecipient> RuntimeStateRecipientBuffer =
+            new List<RuntimeStateRecipient>();
+        private static readonly List<GroupRuntimeState> RuntimeStateVisibleBuffer =
+            new List<GroupRuntimeState>();
 
         private void RunRuntimeStateSyncTick()
         {
@@ -171,12 +178,13 @@ namespace ShipCoreFramework
 
         private static List<RuntimeStateRecipient> CollectRuntimeStateRecipients()
         {
-            var players = new List<IMyPlayer>();
-            MyAPIGateway.Players.GetPlayers(players);
-            var recipients = new List<RuntimeStateRecipient>();
-            for (var i = 0; i < players.Count; i++)
+            RuntimeStatePlayerBuffer.Clear();
+            MyAPIGateway.Players.GetPlayers(RuntimeStatePlayerBuffer);
+            var recipients = RuntimeStateRecipientBuffer;
+            recipients.Clear();
+            for (var i = 0; i < RuntimeStatePlayerBuffer.Count; i++)
             {
-                var player = players[i];
+                var player = RuntimeStatePlayerBuffer[i];
                 if (player == null || player.SteamUserId == 0) continue;
                 if (LocalPlayer != null && player.SteamUserId == LocalPlayer.SteamUserId) continue;
                 recipients.Add(new RuntimeStateRecipient
@@ -192,42 +200,41 @@ namespace ShipCoreFramework
         {
             position = Vector3D.Zero;
             if (steamId == 0) return false;
-            var players = new List<IMyPlayer>();
-            MyAPIGateway.Players.GetPlayers(players);
-            for (var i = 0; i < players.Count; i++)
+            RuntimeStatePlayerBuffer.Clear();
+            MyAPIGateway.Players.GetPlayers(RuntimeStatePlayerBuffer);
+            for (var i = 0; i < RuntimeStatePlayerBuffer.Count; i++)
             {
-                if (players[i] == null || players[i].SteamUserId != steamId) continue;
-                position = players[i].GetPosition();
+                var player = RuntimeStatePlayerBuffer[i];
+                if (player == null || player.SteamUserId != steamId) continue;
+                position = player.GetPosition();
                 return true;
             }
             return false;
         }
 
-        private static Vector3D[] GetGroupPositions(GroupComponent group)
-        {
-            var gridStates = group.GetCachedGridStates();
-            if (gridStates == null || gridStates.Length == 0) return Array.Empty<Vector3D>();
-            var positions = new Vector3D[gridStates.Length];
-            for (var i = 0; i < gridStates.Length; i++) positions[i] = gridStates[i].Position;
-            return positions;
-        }
-
-        private static bool IsWithinRange(Vector3D[] positions, Vector3D viewer, double rangeSquared)
-        {
-            if (positions == null) return false;
-            for (var i = 0; i < positions.Length; i++)
-                if (Vector3D.DistanceSquared(positions[i], viewer) <= rangeSquared) return true;
-            return false;
-        }
-
+        /// <summary>
+        /// Selects the states visible to one viewer. The distance test is written inline on
+        /// purpose: the mod profiler rewriter wraps every mod method, property and lambda in a
+        /// try/finally with two profiler calls, which also blocks JIT inlining, so a leaf
+        /// helper called once per entry per player would cost far more than the arithmetic.
+        /// Vector3D comes from the game binaries and is not rewritten.
+        /// Returns a shared buffer, valid until the next call.
+        /// </summary>
         private static List<GroupRuntimeState> FilterRuntimeStates(List<RuntimeStateEntry> entries,
             Vector3D viewer, double rangeSquared)
         {
-            var visible = new List<GroupRuntimeState>();
+            var visible = RuntimeStateVisibleBuffer;
+            visible.Clear();
             for (var i = 0; i < entries.Count; i++)
             {
-                if (!IsWithinRange(entries[i].Positions, viewer, rangeSquared)) continue;
-                visible.Add(entries[i].State);
+                var grids = entries[i].Grids;
+                if (grids == null) continue;
+                for (var j = 0; j < grids.Length; j++)
+                {
+                    if (Vector3D.DistanceSquared(grids[j].Position, viewer) > rangeSquared) continue;
+                    visible.Add(entries[i].State);
+                    break;
+                }
             }
             return visible;
         }
@@ -246,19 +253,16 @@ namespace ShipCoreFramework
                 if (group == null) continue;
                 var state = group.BuildRuntimeState(revision);
                 if (state == null) continue;
-                var positions = GetGroupPositions(group);
-                entries.Add(new RuntimeStateEntry { State = state, Positions = positions });
-                knownStates[group] = new RuntimeStateIdentity(state.GroupId, state.GridIds, positions);
+                var grids = group.GetCachedGridStates();
+                entries.Add(new RuntimeStateEntry { State = state, Grids = grids });
+                knownStates[group] = new RuntimeStateIdentity(state.GroupId, state.GridIds, grids);
             }
             RuntimeStateKnown.Clear();
             foreach (var pair in knownStates) RuntimeStateKnown[pair.Key] = pair.Value;
-            entries.Sort(CompareEntriesByGroupId);
+            // Non-capturing lambda, so Roslyn caches the delegate in a static. Naming
+            // Comparison<T> directly is rejected by the mod whitelist.
+            entries.Sort((left, right) => left.State.GroupId.CompareTo(right.State.GroupId));
             return entries;
-        }
-
-        private static int CompareEntriesByGroupId(RuntimeStateEntry left, RuntimeStateEntry right)
-        {
-            return left.State.GroupId.CompareTo(right.State.GroupId);
         }
 
         private static PacketRuntimeState[] BuildRuntimeStatePackets(List<GroupRuntimeState> states,
@@ -341,9 +345,9 @@ namespace ShipCoreFramework
                 var state = group.BuildRuntimeState(revision);
                 if (state != null)
                 {
-                    var positions = GetGroupPositions(group);
-                    entries.Add(new RuntimeStateEntry { State = state, Positions = positions });
-                    RuntimeStateKnown[group] = new RuntimeStateIdentity(state.GroupId, state.GridIds, positions);
+                    var grids = group.GetCachedGridStates();
+                    entries.Add(new RuntimeStateEntry { State = state, Grids = grids });
+                    RuntimeStateKnown[group] = new RuntimeStateIdentity(state.GroupId, state.GridIds, grids);
                     continue;
                 }
 
@@ -360,11 +364,13 @@ namespace ShipCoreFramework
                         GridIds = identity.GridIds,
                         Removed = true
                     },
-                    Positions = identity.Positions
+                    Grids = identity.Grids
                 });
             }
             RemoveSupersededTombstones(entries);
-            entries.Sort(CompareEntriesByGroupId);
+            // Non-capturing lambda, so Roslyn caches the delegate in a static. Naming
+            // Comparison<T> directly is rejected by the mod whitelist.
+            entries.Sort((left, right) => left.State.GroupId.CompareTo(right.State.GroupId));
             return entries;
         }
 
@@ -436,20 +442,23 @@ namespace ShipCoreFramework
         private struct RuntimeStateEntry
         {
             internal GroupRuntimeState State;
-            internal Vector3D[] Positions;
+            internal GroupComponent.CachedGridState[] Grids;
         }
 
         private sealed class RuntimeStateIdentity
         {
             internal readonly long GroupId;
             internal readonly long[] GridIds;
-            internal readonly Vector3D[] Positions;
+            internal readonly GroupComponent.CachedGridState[] Grids;
 
-            internal RuntimeStateIdentity(long groupId, long[] gridIds, Vector3D[] positions)
+            internal RuntimeStateIdentity(long groupId, long[] gridIds,
+                GroupComponent.CachedGridState[] grids)
             {
                 GroupId = groupId;
                 GridIds = gridIds == null ? Array.Empty<long>() : (long[])gridIds.Clone();
-                Positions = positions == null ? Array.Empty<Vector3D>() : (Vector3D[])positions.Clone();
+                // Not cloned: the cache is replaced wholesale rather than mutated in place, so
+                // holding the reference gives a stable view of the group as it last existed.
+                Grids = grids ?? Array.Empty<GroupComponent.CachedGridState>();
             }
         }
     }

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Session/Server/Session.RuntimeStatePublisher.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Session/Server/Session.RuntimeStatePublisher.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Sandbox.ModAPI;
 using VRage.Game.ModAPI;
+using VRageMath;
 
 namespace ShipCoreFramework
 {
@@ -14,6 +15,9 @@ namespace ShipCoreFramework
         // Scanning every group for liveness is O(groups + grids); at 60Hz that is pure overhead.
         // 120 is a multiple of this, so the full-snapshot tick always includes a fresh scan.
         private const int RuntimeStateRemovalScanIntervalTicks = 30;
+        // Used only when session settings are unavailable. Never fall back to "no filtering",
+        // because that would publish the whole world to every client.
+        private const double RuntimeStateFallbackRangeMeters = 15000d;
         private static int _runtimeStateSequence;
         private static int _runtimeStateRevision;
         private static readonly ConcurrentDictionary<GroupComponent, byte> RuntimeStateDirty =
@@ -32,17 +36,7 @@ namespace ShipCoreFramework
             var fullSnapshot = CurrentTick % RuntimeStateSyncIntervalTicks == 0;
             if (!fullSnapshot && RuntimeStateDirty.IsEmpty) return;
 
-            var players = new List<IMyPlayer>();
-            MyAPIGateway.Players.GetPlayers(players);
-            var recipients = new List<ulong>();
-            for (var i = 0; i < players.Count; i++)
-            {
-                var player = players[i];
-                if (player == null || player.SteamUserId == 0) continue;
-                if (LocalPlayer != null && player.SteamUserId == LocalPlayer.SteamUserId) continue;
-                recipients.Add(player.SteamUserId);
-            }
-
+            var recipients = CollectRuntimeStateRecipients();
             var dirtyGroups = CaptureRuntimeStateDirty();
             if (recipients.Count == 0)
             {
@@ -50,14 +44,37 @@ namespace ShipCoreFramework
                 return;
             }
 
+            var rangeSquared = GetRuntimeStateRangeSquared();
+
             if (fullSnapshot)
             {
-                SendRuntimeStatePacketsToAll(BuildRuntimeStatePackets(), recipients);
+                int sequence;
+                int revision;
+                var entries = BuildRuntimeStateEntries(out sequence, out revision);
+                for (var i = 0; i < recipients.Count; i++)
+                {
+                    var recipient = recipients[i];
+                    var visible = FilterRuntimeStates(entries, recipient.Position, rangeSquared);
+                    // An empty snapshot still has to go out: the client clears and rebuilds its
+                    // store on every snapshot, so this is what drops states left behind by a
+                    // player who moved away from everything.
+                    SendRuntimeStatePacketsTo(BuildRuntimeStatePackets(visible, sequence, revision),
+                        recipient.SteamId);
+                }
                 return;
             }
 
-            SendRuntimeStateDeltaPacketsToAll(BuildRuntimeStateDeltaPackets(dirtyGroups), recipients);
+            var deltaEntries = BuildRuntimeStateDeltaEntries(dirtyGroups);
+            if (deltaEntries.Count == 0) return;
+            for (var i = 0; i < recipients.Count; i++)
+            {
+                var recipient = recipients[i];
+                var visible = FilterRuntimeStates(deltaEntries, recipient.Position, rangeSquared);
+                if (visible.Count == 0) continue;
+                SendRuntimeStateDeltaPacketsTo(BuildRuntimeStateDeltaPackets(visible), recipient.SteamId);
+            }
         }
+
         internal static void SendRuntimeStateTo(ulong steamId)
         {
             if (!IsServer || steamId == 0 || Networking == null) return;
@@ -65,8 +82,17 @@ namespace ShipCoreFramework
             if (RuntimeStateRequestTicks.TryGetValue(steamId, out lastRequestTick) &&
                 CurrentTick - lastRequestTick < RuntimeStateRequestCooldownTicks)
                 return;
+            // Only burn the cooldown once we can actually answer. A client that asks before
+            // its player entity is registered would otherwise wait out the full cooldown.
+            Vector3D viewer;
+            if (!TryGetPlayerPosition(steamId, out viewer)) return;
             RuntimeStateRequestTicks[steamId] = CurrentTick;
-            SendRuntimeStatePacketsTo(BuildRuntimeStatePackets(), steamId);
+
+            int sequence;
+            int revision;
+            var entries = BuildRuntimeStateEntries(out sequence, out revision);
+            var visible = FilterRuntimeStates(entries, viewer, GetRuntimeStateRangeSquared());
+            SendRuntimeStatePacketsTo(BuildRuntimeStatePackets(visible, sequence, revision), steamId);
         }
 
         internal static bool CanServeConfigRequest(ulong steamId)
@@ -129,11 +155,90 @@ namespace ShipCoreFramework
             return false;
         }
 
-        private static PacketRuntimeState[] BuildRuntimeStatePackets()
+        // ---- relevance ----------------------------------------------------------------
+
+        /// <summary>
+        /// Squared broadcast radius. Clients are only told about groups they could observe
+        /// in game, so runtime state cannot be used to see past render range.
+        /// </summary>
+        private static double GetRuntimeStateRangeSquared()
         {
-            var sequence = ++_runtimeStateSequence;
-            var revision = ++_runtimeStateRevision;
-            var states = new List<GroupRuntimeState>();
+            var settings = MyAPIGateway.Session == null ? null : MyAPIGateway.Session.SessionSettings;
+            double range = settings == null ? 0 : settings.ViewDistance;
+            if (range <= 0d) range = RuntimeStateFallbackRangeMeters;
+            return range * range;
+        }
+
+        private static List<RuntimeStateRecipient> CollectRuntimeStateRecipients()
+        {
+            var players = new List<IMyPlayer>();
+            MyAPIGateway.Players.GetPlayers(players);
+            var recipients = new List<RuntimeStateRecipient>();
+            for (var i = 0; i < players.Count; i++)
+            {
+                var player = players[i];
+                if (player == null || player.SteamUserId == 0) continue;
+                if (LocalPlayer != null && player.SteamUserId == LocalPlayer.SteamUserId) continue;
+                recipients.Add(new RuntimeStateRecipient
+                {
+                    SteamId = player.SteamUserId,
+                    Position = player.GetPosition()
+                });
+            }
+            return recipients;
+        }
+
+        private static bool TryGetPlayerPosition(ulong steamId, out Vector3D position)
+        {
+            position = Vector3D.Zero;
+            if (steamId == 0) return false;
+            var players = new List<IMyPlayer>();
+            MyAPIGateway.Players.GetPlayers(players);
+            for (var i = 0; i < players.Count; i++)
+            {
+                if (players[i] == null || players[i].SteamUserId != steamId) continue;
+                position = players[i].GetPosition();
+                return true;
+            }
+            return false;
+        }
+
+        private static Vector3D[] GetGroupPositions(GroupComponent group)
+        {
+            var gridStates = group.GetCachedGridStates();
+            if (gridStates == null || gridStates.Length == 0) return Array.Empty<Vector3D>();
+            var positions = new Vector3D[gridStates.Length];
+            for (var i = 0; i < gridStates.Length; i++) positions[i] = gridStates[i].Position;
+            return positions;
+        }
+
+        private static bool IsWithinRange(Vector3D[] positions, Vector3D viewer, double rangeSquared)
+        {
+            if (positions == null) return false;
+            for (var i = 0; i < positions.Length; i++)
+                if (Vector3D.DistanceSquared(positions[i], viewer) <= rangeSquared) return true;
+            return false;
+        }
+
+        private static List<GroupRuntimeState> FilterRuntimeStates(List<RuntimeStateEntry> entries,
+            Vector3D viewer, double rangeSquared)
+        {
+            var visible = new List<GroupRuntimeState>();
+            for (var i = 0; i < entries.Count; i++)
+            {
+                if (!IsWithinRange(entries[i].Positions, viewer, rangeSquared)) continue;
+                visible.Add(entries[i].State);
+            }
+            return visible;
+        }
+
+        // ---- snapshot building --------------------------------------------------------
+
+        private static List<RuntimeStateEntry> BuildRuntimeStateEntries(out int sequence, out int revision)
+        {
+            sequence = ++_runtimeStateSequence;
+            revision = ++_runtimeStateRevision;
+            var entries = new List<RuntimeStateEntry>();
             var knownStates = new Dictionary<GroupComponent, RuntimeStateIdentity>();
             foreach (var pair in GroupDict)
             {
@@ -141,13 +246,24 @@ namespace ShipCoreFramework
                 if (group == null) continue;
                 var state = group.BuildRuntimeState(revision);
                 if (state == null) continue;
-                states.Add(state);
-                knownStates[group] = new RuntimeStateIdentity(state.GroupId, state.GridIds);
+                var positions = GetGroupPositions(group);
+                entries.Add(new RuntimeStateEntry { State = state, Positions = positions });
+                knownStates[group] = new RuntimeStateIdentity(state.GroupId, state.GridIds, positions);
             }
             RuntimeStateKnown.Clear();
             foreach (var pair in knownStates) RuntimeStateKnown[pair.Key] = pair.Value;
-            states.Sort((left, right) => left.GroupId.CompareTo(right.GroupId));
+            entries.Sort(CompareEntriesByGroupId);
+            return entries;
+        }
 
+        private static int CompareEntriesByGroupId(RuntimeStateEntry left, RuntimeStateEntry right)
+        {
+            return left.State.GroupId.CompareTo(right.State.GroupId);
+        }
+
+        private static PacketRuntimeState[] BuildRuntimeStatePackets(List<GroupRuntimeState> states,
+            int sequence, int revision)
+        {
             if (states.Count == 0)
             {
                 return new[]
@@ -213,34 +329,57 @@ namespace ShipCoreFramework
             Utils.Log("Runtime state skipped for oversized group " + states[offset].GroupId + ".", 1);
         }
 
-        private static PacketRuntimeStateDelta[] BuildRuntimeStateDeltaPackets(List<GroupComponent> dirtyGroups)
+        // ---- delta building -----------------------------------------------------------
+
+        private static List<RuntimeStateEntry> BuildRuntimeStateDeltaEntries(List<GroupComponent> dirtyGroups)
         {
             var revision = ++_runtimeStateRevision;
-            var states = new List<GroupRuntimeState>();
+            var entries = new List<RuntimeStateEntry>();
             for (var i = 0; i < dirtyGroups.Count; i++)
             {
                 var group = dirtyGroups[i];
                 var state = group.BuildRuntimeState(revision);
                 if (state != null)
                 {
-                    states.Add(state);
-                    RuntimeStateKnown[group] = new RuntimeStateIdentity(state.GroupId, state.GridIds);
+                    var positions = GetGroupPositions(group);
+                    entries.Add(new RuntimeStateEntry { State = state, Positions = positions });
+                    RuntimeStateKnown[group] = new RuntimeStateIdentity(state.GroupId, state.GridIds, positions);
                     continue;
                 }
 
                 RuntimeStateIdentity identity;
                 if (!RuntimeStateKnown.TryRemove(group, out identity)) continue;
-                states.Add(new GroupRuntimeState
+                // A tombstone is filtered against the group's last known position, so a removal
+                // is only announced to players who were close enough to have been told about it.
+                entries.Add(new RuntimeStateEntry
                 {
-                    GroupId = identity.GroupId,
-                    Revision = revision,
-                    GridIds = identity.GridIds,
-                    Removed = true
+                    State = new GroupRuntimeState
+                    {
+                        GroupId = identity.GroupId,
+                        Revision = revision,
+                        GridIds = identity.GridIds,
+                        Removed = true
+                    },
+                    Positions = identity.Positions
                 });
             }
-            RemoveSupersededTombstones(states);
-            states.Sort((left, right) => left.GroupId.CompareTo(right.GroupId));
+            RemoveSupersededTombstones(entries);
+            entries.Sort(CompareEntriesByGroupId);
+            return entries;
+        }
 
+        private static void RemoveSupersededTombstones(List<RuntimeStateEntry> entries)
+        {
+            var activeGroupIds = new HashSet<long>();
+            for (var i = 0; i < entries.Count; i++)
+                if (!entries[i].State.Removed) activeGroupIds.Add(entries[i].State.GroupId);
+            for (var i = entries.Count - 1; i >= 0; i--)
+                if (entries[i].State.Removed && activeGroupIds.Contains(entries[i].State.GroupId))
+                    entries.RemoveAt(i);
+        }
+
+        private static PacketRuntimeStateDelta[] BuildRuntimeStateDeltaPackets(List<GroupRuntimeState> states)
+        {
             var packets = new List<PacketRuntimeStateDelta>();
             for (var offset = 0; offset < states.Count; offset += RuntimeStateBatchSize)
             {
@@ -248,15 +387,6 @@ namespace ShipCoreFramework
                 AddSizedRuntimeStateDelta(packets, states, offset, count);
             }
             return packets.ToArray();
-        }
-
-        private static void RemoveSupersededTombstones(List<GroupRuntimeState> states)
-        {
-            var activeGroupIds = new HashSet<long>();
-            for (var i = 0; i < states.Count; i++)
-                if (!states[i].Removed) activeGroupIds.Add(states[i].GroupId);
-            for (var i = states.Count - 1; i >= 0; i--)
-                if (states[i].Removed && activeGroupIds.Contains(states[i].GroupId)) states.RemoveAt(i);
         }
 
         private static void AddSizedRuntimeStateDelta(List<PacketRuntimeStateDelta> packets,
@@ -281,6 +411,8 @@ namespace ShipCoreFramework
             Utils.Log("Runtime delta skipped for oversized group " + states[offset].GroupId + ".", 1);
         }
 
+        // ---- sending ------------------------------------------------------------------
+
         private static void SendRuntimeStatePacketsTo(PacketRuntimeState[] packets, ulong steamId)
         {
             if (packets == null || Networking == null) return;
@@ -288,32 +420,36 @@ namespace ShipCoreFramework
                 Networking.SendToPlayer(packets[i], steamId);
         }
 
-        // Loop packets on the outside and recipients on the inside: each packet is serialized
-        // once and the buffer is reused, instead of re-encoding it per player.
-        private static void SendRuntimeStatePacketsToAll(PacketRuntimeState[] packets, List<ulong> recipients)
+        private static void SendRuntimeStateDeltaPacketsTo(PacketRuntimeStateDelta[] packets, ulong steamId)
         {
-            if (packets == null || recipients == null || Networking == null) return;
+            if (packets == null || Networking == null) return;
             for (var i = 0; i < packets.Length; i++)
-                Networking.SendToPlayers(packets[i], recipients);
+                Networking.SendToPlayer(packets[i], steamId);
         }
 
-        private static void SendRuntimeStateDeltaPacketsToAll(PacketRuntimeStateDelta[] packets,
-            List<ulong> recipients)
+        private struct RuntimeStateRecipient
         {
-            if (packets == null || recipients == null || Networking == null) return;
-            for (var i = 0; i < packets.Length; i++)
-                Networking.SendToPlayers(packets[i], recipients);
+            internal ulong SteamId;
+            internal Vector3D Position;
+        }
+
+        private struct RuntimeStateEntry
+        {
+            internal GroupRuntimeState State;
+            internal Vector3D[] Positions;
         }
 
         private sealed class RuntimeStateIdentity
         {
             internal readonly long GroupId;
             internal readonly long[] GridIds;
+            internal readonly Vector3D[] Positions;
 
-            internal RuntimeStateIdentity(long groupId, long[] gridIds)
+            internal RuntimeStateIdentity(long groupId, long[] gridIds, Vector3D[] positions)
             {
                 GroupId = groupId;
                 GridIds = gridIds == null ? Array.Empty<long>() : (long[])gridIds.Clone();
+                Positions = positions == null ? Array.Empty<Vector3D>() : (Vector3D[])positions.Clone();
             }
         }
     }

--- a/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Shared/Network/Networking.cs
+++ b/ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Shared/Network/Networking.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Sandbox.ModAPI;
 
 namespace ShipCoreFramework
@@ -58,10 +59,32 @@ namespace ShipCoreFramework
         {
             if (!MyAPIGateway.Multiplayer.IsServer || packet == null ||
                 packet.Direction != PacketDirection.ServerToClient) return;
-            var bytes = MyAPIGateway.Utilities.SerializeToBinary(packet);
+            // Serialize as PacketBase so the ProtoInclude subtype header is emitted; the
+            // receiver deserializes via SerializeFromBinary<PacketBase>.
+            var bytes = MyAPIGateway.Utilities.SerializeToBinary<PacketBase>(packet);
             MyAPIGateway.Multiplayer.SendMessageTo(_channelId, bytes, steamId);
         }
-        
+
+        /// <summary>
+        /// Serializes <paramref name="packet"/> once and reuses that buffer for every recipient.
+        /// Keen copies the array into a per-call BitStream synchronously inside
+        /// MyReplicationLayer.DispatchEvent, so the transport never retains our array and
+        /// sharing it across sends is safe.
+        /// </summary>
+        internal void SendToPlayers(PacketBase packet, List<ulong> steamIds)
+        {
+            if (!MyAPIGateway.Multiplayer.IsServer || packet == null || steamIds == null ||
+                steamIds.Count == 0 || packet.Direction != PacketDirection.ServerToClient) return;
+            var bytes = MyAPIGateway.Utilities.SerializeToBinary<PacketBase>(packet);
+            if (bytes == null) return;
+            for (var i = 0; i < steamIds.Count; i++)
+            {
+                var steamId = steamIds[i];
+                if (steamId == 0) continue;
+                MyAPIGateway.Multiplayer.SendMessageTo(_channelId, bytes, steamId);
+            }
+        }
+
         internal void SendToServer(PacketBase packet, bool onlyToServer = false)
         {
             if (packet == null || packet.Direction != PacketDirection.ClientToServer) return;
@@ -85,7 +108,7 @@ namespace ShipCoreFramework
                 return;
             }
 
-            var bytes = MyAPIGateway.Utilities.SerializeToBinary(packet);
+            var bytes = MyAPIGateway.Utilities.SerializeToBinary<PacketBase>(packet);
             MyAPIGateway.Multiplayer.SendMessageToServer(_channelId, bytes);
         }
     }

--- a/tests/runtime-state-fanout.test.mjs
+++ b/tests/runtime-state-fanout.test.mjs
@@ -74,7 +74,20 @@ assert.doesNotMatch(
 );
 
 const filter = methodBody(publisher, 'private static List<GroupRuntimeState> FilterRuntimeStates(');
-assert.match(filter, /IsWithinRange\(/, 'filtering must be a distance test');
+// The distance test runs once per entry per player, and the mod profiler rewriter wraps
+// every mod method in a try/finally that also blocks JIT inlining. Keep it inline, and
+// keep it on the game-binary Vector3D helper, which is not rewritten.
+assert.match(filter, /Vector3D\.DistanceSquared\(/, 'distance test must be inline');
+assert.doesNotMatch(
+  filter,
+  /IsWithinRange\(|IsRelevant\w*\(/,
+  'do not reintroduce a per-entry helper in the filter loop',
+);
+assert.match(
+  filter,
+  /RuntimeStateVisibleBuffer/,
+  'filter must reuse its output buffer rather than allocate per player',
+);
 
 // Falling back to an unbounded radius would silently restore the leak.
 const range = methodBody(publisher, 'private static double GetRuntimeStateRangeSquared()');
@@ -93,11 +106,11 @@ assert.match(onRequest, /FilterRuntimeStates\(/);
 
 // Tombstones carry the group's last known position so removals are filtered as well.
 const identity = methodBody(publisher, 'private sealed class RuntimeStateIdentity');
-assert.match(identity, /Vector3D\[\] Positions/);
+assert.match(identity, /CachedGridState\[\] Grids/);
 const deltaEntries = methodBody(publisher, 'private static List<RuntimeStateEntry> BuildRuntimeStateDeltaEntries(');
 assert.match(
   deltaEntries,
-  /Positions = identity\.Positions/,
+  /Grids = identity\.Grids/,
   'tombstones must reuse the last known position for filtering',
 );
 

--- a/tests/runtime-state-fanout.test.mjs
+++ b/tests/runtime-state-fanout.test.mjs
@@ -27,7 +27,8 @@ function methodBody(source, signature) {
   throw new Error(`unbalanced braces for ${signature}`);
 }
 
-// --- the core invariant: one serialization, reused across every recipient ---------
+// --- shared-buffer fan-out: one serialization reused across recipients ------------
+// Still used by the notification paths, where every recipient gets identical bytes.
 const fanout = methodBody(networking, 'internal void SendToPlayers(');
 
 const serializeAt = fanout.indexOf('SerializeToBinary');
@@ -49,34 +50,58 @@ assert.equal(
 assert.match(networking, /SerializeToBinary<PacketBase>\(packet\)/);
 assert.doesNotMatch(networking, /SerializeToBinary\(packet\)/);
 
-// --- bulk runtime-state sends must go through the shared-buffer path --------------
-assert.match(publisher, /SendRuntimeStatePacketsToAll\(/);
-assert.match(publisher, /SendRuntimeStateDeltaPacketsToAll\(/);
-assert.doesNotMatch(
-  publisher,
-  /SendRuntimeStateDeltaPacketsTo\(/,
-  'per-recipient delta send should be gone; use the ToAll variant',
-);
-
-for (const sig of [
-  'private static void SendRuntimeStatePacketsToAll(',
-  'private static void SendRuntimeStateDeltaPacketsToAll(',
-]) {
-  const body = methodBody(publisher, sig);
-  assert.match(body, /Networking\.SendToPlayers\(/, `${sig} must use SendToPlayers`);
-  assert.doesNotMatch(
-    body,
-    /Networking\.SendToPlayer\(/,
-    `${sig} must not fall back to the single-recipient send`,
-  );
+for (const sig of ['static partial void ForwardServerLogMessage(', 'internal static void ShowNotification(']) {
+  const body = methodBody(notifications, sig);
+  assert.match(body, /SendToPlayers\(/, `${sig} must batch its fan-out`);
 }
 
-// The single-recipient path is still needed for join-time state requests.
-assert.match(publisher, /private static void SendRuntimeStatePacketsTo\(/);
+// --- runtime state must be range filtered per recipient ---------------------------
+// Clients may only be told about groups they could observe in game.
+const syncTick = methodBody(publisher, 'private void RunRuntimeStateSyncTick()');
+
+assert.match(syncTick, /GetRuntimeStateRangeSquared\(\)/);
+assert.equal(
+  (syncTick.match(/FilterRuntimeStates\(/g) || []).length,
+  2,
+  'both the snapshot and delta paths must filter by range',
+);
+// Range filtering is per player, so the shared-buffer helper must not be used here:
+// it would send one recipient's visible set to everybody.
+assert.doesNotMatch(
+  syncTick,
+  /SendToPlayers\(/,
+  'runtime state must not use the shared-buffer fan-out after filtering',
+);
+
+const filter = methodBody(publisher, 'private static List<GroupRuntimeState> FilterRuntimeStates(');
+assert.match(filter, /IsWithinRange\(/, 'filtering must be a distance test');
+
+// Falling back to an unbounded radius would silently restore the leak.
+const range = methodBody(publisher, 'private static double GetRuntimeStateRangeSquared()');
+assert.match(range, /ViewDistance/);
+assert.match(range, /RuntimeStateFallbackRangeMeters/);
+assert.doesNotMatch(
+  range,
+  /double\.MaxValue|MaxValue/,
+  'range must never fall back to unbounded',
+);
+
+// The join-time request path is a full snapshot too, so it needs the same filter.
+const onRequest = methodBody(publisher, 'internal static void SendRuntimeStateTo(');
+assert.match(onRequest, /TryGetPlayerPosition\(/);
+assert.match(onRequest, /FilterRuntimeStates\(/);
+
+// Tombstones carry the group's last known position so removals are filtered as well.
+const identity = methodBody(publisher, 'private sealed class RuntimeStateIdentity');
+assert.match(identity, /Vector3D\[\] Positions/);
+const deltaEntries = methodBody(publisher, 'private static List<RuntimeStateEntry> BuildRuntimeStateDeltaEntries(');
+assert.match(
+  deltaEntries,
+  /Positions = identity\.Positions/,
+  'tombstones must reuse the last known position for filtering',
+);
 
 // --- the O(groups) liveness scan must not run every tick --------------------------
-assert.match(publisher, /RuntimeStateRemovalScanIntervalTicks/);
-const syncTick = methodBody(publisher, 'private void RunRuntimeStateSyncTick()');
 assert.match(
   syncTick,
   /CurrentTick % RuntimeStateRemovalScanIntervalTicks == 0\) QueueRemovedRuntimeStates\(\)/,
@@ -84,22 +109,12 @@ assert.match(
 );
 
 // The full-snapshot tick must always coincide with a fresh removal scan.
-const interval = Number(
-  /RuntimeStateSyncIntervalTicks = (\d+)/.exec(publisher)[1],
-);
-const scan = Number(
-  /RuntimeStateRemovalScanIntervalTicks = (\d+)/.exec(publisher)[1],
-);
+const interval = Number(/RuntimeStateSyncIntervalTicks = (\d+)/.exec(publisher)[1]);
+const scan = Number(/RuntimeStateRemovalScanIntervalTicks = (\d+)/.exec(publisher)[1]);
 assert.equal(
   interval % scan,
   0,
   'snapshot interval must be a multiple of the removal-scan interval',
 );
-
-// --- notification fan-outs share one buffer too -----------------------------------
-for (const sig of ['static partial void ForwardServerLogMessage(', 'internal static void ShowNotification(']) {
-  const body = methodBody(notifications, sig);
-  assert.match(body, /SendToPlayers\(/, `${sig} must batch its fan-out`);
-}
 
 console.log('runtime-state-fanout: ok');

--- a/tests/runtime-state-fanout.test.mjs
+++ b/tests/runtime-state-fanout.test.mjs
@@ -91,7 +91,10 @@ assert.match(
 
 // Falling back to an unbounded radius would silently restore the leak.
 const range = methodBody(publisher, 'private static double GetRuntimeStateRangeSquared()');
-assert.match(range, /ViewDistance/);
+// SyncDistance, not ViewDistance: it is the engine's grid replication radius, so it is
+// the tightest defensible bound on what a client could observe.
+assert.match(range, /SyncDistance/);
+assert.doesNotMatch(range, /ViewDistance/);
 assert.match(range, /RuntimeStateFallbackRangeMeters/);
 assert.doesNotMatch(
   range,

--- a/tests/runtime-state-fanout.test.mjs
+++ b/tests/runtime-state-fanout.test.mjs
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const networking = fs.readFileSync(
+  'ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Shared/Network/Networking.cs',
+  'utf8',
+);
+const publisher = fs.readFileSync(
+  'ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Session/Server/Session.RuntimeStatePublisher.cs',
+  'utf8',
+);
+const notifications = fs.readFileSync(
+  'ShipCoreFramework/src/Data/Scripts/ShipCoreFramework/Server/Utilities/Utils.Notifications.cs',
+  'utf8',
+);
+
+// Extracts a method body by brace matching from the signature onward.
+function methodBody(source, signature) {
+  const start = source.indexOf(signature);
+  assert.notEqual(start, -1, `missing method: ${signature}`);
+  const open = source.indexOf('{', start);
+  let depth = 0;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}' && --depth === 0) return source.slice(open, i + 1);
+  }
+  throw new Error(`unbalanced braces for ${signature}`);
+}
+
+// --- the core invariant: one serialization, reused across every recipient ---------
+const fanout = methodBody(networking, 'internal void SendToPlayers(');
+
+const serializeAt = fanout.indexOf('SerializeToBinary');
+const loopAt = fanout.indexOf('for (');
+assert.notEqual(serializeAt, -1, 'SendToPlayers must serialize the packet');
+assert.notEqual(loopAt, -1, 'SendToPlayers must loop over recipients');
+assert.ok(
+  serializeAt < loopAt,
+  'SendToPlayers must serialize BEFORE the recipient loop, not inside it',
+);
+assert.equal(
+  (fanout.match(/SerializeToBinary/g) || []).length,
+  1,
+  'SendToPlayers must serialize exactly once per packet',
+);
+
+// Serializing as the concrete type would drop the ProtoInclude subtype header and
+// break SerializeFromBinary<PacketBase> on the receiving end.
+assert.match(networking, /SerializeToBinary<PacketBase>\(packet\)/);
+assert.doesNotMatch(networking, /SerializeToBinary\(packet\)/);
+
+// --- bulk runtime-state sends must go through the shared-buffer path --------------
+assert.match(publisher, /SendRuntimeStatePacketsToAll\(/);
+assert.match(publisher, /SendRuntimeStateDeltaPacketsToAll\(/);
+assert.doesNotMatch(
+  publisher,
+  /SendRuntimeStateDeltaPacketsTo\(/,
+  'per-recipient delta send should be gone; use the ToAll variant',
+);
+
+for (const sig of [
+  'private static void SendRuntimeStatePacketsToAll(',
+  'private static void SendRuntimeStateDeltaPacketsToAll(',
+]) {
+  const body = methodBody(publisher, sig);
+  assert.match(body, /Networking\.SendToPlayers\(/, `${sig} must use SendToPlayers`);
+  assert.doesNotMatch(
+    body,
+    /Networking\.SendToPlayer\(/,
+    `${sig} must not fall back to the single-recipient send`,
+  );
+}
+
+// The single-recipient path is still needed for join-time state requests.
+assert.match(publisher, /private static void SendRuntimeStatePacketsTo\(/);
+
+// --- the O(groups) liveness scan must not run every tick --------------------------
+assert.match(publisher, /RuntimeStateRemovalScanIntervalTicks/);
+const syncTick = methodBody(publisher, 'private void RunRuntimeStateSyncTick()');
+assert.match(
+  syncTick,
+  /CurrentTick % RuntimeStateRemovalScanIntervalTicks == 0\) QueueRemovedRuntimeStates\(\)/,
+  'QueueRemovedRuntimeStates must be interval-gated, not called every tick',
+);
+
+// The full-snapshot tick must always coincide with a fresh removal scan.
+const interval = Number(
+  /RuntimeStateSyncIntervalTicks = (\d+)/.exec(publisher)[1],
+);
+const scan = Number(
+  /RuntimeStateRemovalScanIntervalTicks = (\d+)/.exec(publisher)[1],
+);
+assert.equal(
+  interval % scan,
+  0,
+  'snapshot interval must be a multiple of the removal-scan interval',
+);
+
+// --- notification fan-outs share one buffer too -----------------------------------
+for (const sig of ['static partial void ForwardServerLogMessage(', 'internal static void ShowNotification(']) {
+  const body = methodBody(notifications, sig);
+  assert.match(body, /SendToPlayers\(/, `${sig} must batch its fan-out`);
+}
+
+console.log('runtime-state-fanout: ok');


### PR DESCRIPTION
## Problem

Two issues in the runtime state publisher.

**Information leak.** Every client received runtime state for every grid group in the world, with no distance or ownership filter. That includes owner id, mass, dry mass, PCU, block count, effective speed and the boost, active defense and power overclock cooldown timers. A player could read the exact composition of any ship on the server and see whether a hostile core was on cooldown before engaging. Coreless grids were included too, since they fall back to the no core config and still carry a limits array. Much of it was unusable even to an honest client, because grids beyond replication range have no local entity for the state to attach to.

**Fan-out cost.** `SendToPlayer` calls `SerializeToBinary` internally and the publisher looped recipients around it, so every packet was encoded once per recipient. At 100 players with 150 grid groups a full snapshot ran about 300 protobuf encodes and allocated around 20MB, all on the game thread every 2 seconds. The dominant cost is allocation and GC pressure rather than encode throughput.

## Changes

- Filter each recipient's snapshot and delta against `SessionSettings.SyncDistance`, the radius at which the engine replicates grid entities, using the already cached grid positions. The join time request path uses the same filter. If session settings are unavailable the radius falls back to the stock 3000 default, never to unbounded.
- Filter tombstones against the group's last known position, so a removal is only announced to players who were told about the group.
- Add `Networking.SendToPlayers`, which encodes once and reuses the buffer. Safe because Keen copies the array into a per-call BitStream inside `MyReplicationLayer.DispatchEvent`. Used by the debug log and combat log fan-out, where every recipient gets identical bytes.
- Gate `QueueRemovedRuntimeStates` to every 30 ticks instead of every tick. It was running an O(groups) scan at 60Hz before the early return. 120 is a multiple of 30, so every full snapshot still gets a fresh scan.
- Guard null `CoreBlock` dereferences in `BuildRuntimeState`, `ResetCore` and `CoreTerminalControls`. `MainCoreComponent` was null checked but `CoreBlock` was not, so a snapshot taken between core destruction and failover could throw.

## Profiler overhead

`PerfCountingRewriter` wraps every mod method, property, accessor and lambda in a try/finally with two profiler calls, which also prevents the JIT from inlining them, so small leaf helpers on hot paths are the worst case. The per-entry distance test ran once per group per player on every delta tick, roughly 120k calls per second at 100 players, so it is written inline. `Vector3D` comes from the game binaries and is not rewritten. The player, recipient and visible-state buffers are reused rather than allocated per tick, and the cached grid state array is held directly rather than copied into a positions array per group per snapshot.

## Trade offs

Range filtering is per player, so runtime state no longer shares a single encoded buffer. The net is a large reduction in traffic for a smaller rise in encode work, still well below the original cost. Notification fan-out keeps the shared buffer since those bytes are identical for everyone.

A group entering range populates on the next full snapshot, so up to 2 seconds. Players who move away keep stale state for the same window, then the snapshot rebuild drops it.

There is no ownership exemption. A player does not receive state for their own grids beyond sync range, matching what they could observe in game.

## Testing

Builds clean against MDK2 with no new warnings, which also confirms `SessionSettings.SyncDistance` is whitelisted. All source assertion tests pass, including `tests/runtime-state-fanout.test.mjs`, which covers the serialize once invariant, range filtering on both send paths, that the radius uses SyncDistance and never falls back to unbounded, and that the distance test stays inline.

Not yet verified in a live world.
